### PR TITLE
feature: Add anonymous post support with database integration and testing

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -155,6 +155,9 @@ PostObject:
       type: boolean
     replies:
       type: number
+    anonymous:
+      type: number
+      description: Whether the post is anonymous (1) or not (0)
 PostDataObject:
   description: The output as returned from `Posts.getPostsData`
   allOf:
@@ -195,6 +198,9 @@ PostDataObject:
           type: string
         index:
           type: number
+        anonymous:
+          type: number
+          description: Whether the post is anonymous (1) or not (0)
         user:
           type: object
           properties:

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -190,7 +190,7 @@ topicsAPI.updateTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	await topics.updateTopicTags(tid, tags);
 	return await topics.getTopicTagsObjects(tid);
 };
@@ -201,7 +201,7 @@ topicsAPI.addTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	tags = await topics.filterTags(tags, cid);
 
 	await topics.addTags(tags, [tid]);

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -39,6 +39,7 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+		postData.anonymous = data.anonymous || 0;
 		if (_activitypub) {
 			if (_activitypub.url) {
 				postData.url = _activitypub.url;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'anonymous',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -139,7 +139,7 @@ module.exports = function (Posts) {
 			if (!canTag) {
 				throw new Error('[[error:no-privileges]]');
 			}
-			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
+			await topics.validateTags({ tags: data.tags, cid: topicData.cid, uid: data.uid, tid: tid });
 		}
 
 		const results = await plugins.hooks.fire('filter:topic.edit', {

--- a/src/posts/queue.js
+++ b/src/posts/queue.js
@@ -266,7 +266,7 @@ module.exports = function (Posts) {
 		if (type === 'topic') {
 			topics.checkTitle(data.title);
 			if (data.tags) {
-				await topics.validateTags(data.tags, cid, data.uid);
+				await topics.validateTags({ tags: data.tags, cid: cid, uid: data.uid });
 			}
 		}
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -22,7 +22,7 @@ module.exports = function (Posts) {
 		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -133,12 +133,14 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: true };
 	}
 
+	let errorMessage = null;
+
 	if (
 		!isRemote && !results.isMod &&
 		meta.config.postEditDuration &&
 		(Date.now() - results.postData.timestamp > meta.config.postEditDuration * 1000)
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]`;
 	}
 	if (
 		!isRemote && !results.isMod &&
@@ -146,16 +148,20 @@ privsPosts.canEdit = async function (pid, uid) {
 		meta.config.newbieReputationThreshold > results.userData.reputation &&
 		Date.now() - results.postData.timestamp > meta.config.newbiePostEditDuration * 1000
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]`;
 	}
 
 	const isLocked = await topics.isLocked(results.postData.tid);
 	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
+		errorMessage = '[[error:topic-locked]]';
 	}
 
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
+		errorMessage = '[[error:post-deleted]]';
+	}
+
+	if (errorMessage) {
+		return { flag: false, message: errorMessage };
 	}
 
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -98,7 +98,7 @@ module.exports = function (Topics) {
 			Topics.checkTitle(data.title);
 		}
 
-		await Topics.validateTags(data.tags, data.cid, uid);
+		await Topics.validateTags({ tags: data.tags, cid: data.cid, uid: uid });
 		data.tags = await Topics.filterTags(data.tags, data.cid);
 		if (!data.fromQueue && !isAdmin) {
 			Topics.checkContent(data.sourceContent || data.content);

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -66,7 +66,8 @@ module.exports = function (Topics) {
 		);
 	};
 
-	Topics.validateTags = async function (tags, cid, uid, tid = null) {
+	Topics.validateTags = async function ({ tags, cid, uid, tid}) {
+		tid = tid ?? null;
 		if (!Array.isArray(tags)) {
 			throw new Error('[[error:invalid-data]]');
 		}

--- a/src/upgrades/4.4.0/add-anonymous-field-to-posts.js
+++ b/src/upgrades/4.4.0/add-anonymous-field-to-posts.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const db = require('../../database');
+const batch = require('../../batch');
+
+module.exports = {
+	name: 'Add anonymous field to posts',
+	timestamp: Date.UTC(2025, 8, 21),
+	method: async function () {
+		const { progress } = this;
+		
+		// Get all post keys
+		const postKeys = await db.getSortedSetRange('posts:pid', 0, -1);
+		progress.total = postKeys.length;
+
+		await batch.processArray(postKeys, async (pids) => {
+			progress.incr(pids.length);
+			
+			// Get all post objects
+			const keys = pids.map(pid => `post:${pid}`);
+			const posts = await db.getObjects(keys);
+			
+			// Update posts that don't have the anonymous field
+			const updates = [];
+			posts.forEach((post, index) => {
+				if (post && !post.hasOwnProperty('anonymous')) {
+					updates.push([keys[index], { anonymous: 0 }]);
+				}
+			});
+			
+			if (updates.length > 0) {
+				await db.setObjectBulk(updates);
+			}
+		}, {
+			progress: progress,
+			batch: 500,
+		});
+	},
+};

--- a/test/posts/anonymous.js
+++ b/test/posts/anonymous.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const assert = require('assert');
+
+const db = require('../mocks/databasemock');
+const posts = require('../../src/posts');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const user = require('../../src/user');
+
+describe('Anonymous Posts', () => {
+	let testUid;
+	let testCid;
+	let topicData;
+	let postData;
+
+	before(async () => {
+		testUid = await user.create({ username: 'testuser' });
+		({ cid: testCid } = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for anonymous posts',
+		}));
+	});
+
+	it('should create a regular post without anonymous field', async () => {
+		({ topicData, postData } = await topics.post({
+			uid: testUid,
+			cid: testCid,
+			title: 'Regular Post',
+			content: 'This is a regular post',
+		}));
+
+		const post = await posts.getPostData(postData.pid);
+		assert(post);
+		assert.strictEqual(post.anonymous, 0);
+		assert.strictEqual(post.uid, testUid);
+		assert.strictEqual(post.content, 'This is a regular post');
+	});
+
+	it('should create an anonymous post with anonymous field set to 1', async () => {
+		const anonymousPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is an anonymous post',
+			anonymous: 1,
+		});
+
+		assert(anonymousPost);
+		assert.strictEqual(anonymousPost.anonymous, 1);
+		assert.strictEqual(anonymousPost.uid, testUid);
+		assert.strictEqual(anonymousPost.content, 'This is an anonymous post');
+
+		// Verify the post was stored correctly in the database
+		const storedPost = await posts.getPostData(anonymousPost.pid);
+		assert.strictEqual(storedPost.anonymous, 1);
+	});
+
+	it('should create a reply with anonymous field', async () => {
+		const anonymousReply = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is an anonymous reply',
+			anonymous: 1,
+		});
+
+		assert(anonymousReply);
+		assert.strictEqual(anonymousReply.anonymous, 1);
+		assert.strictEqual(anonymousReply.uid, testUid);
+		assert.strictEqual(anonymousReply.content, 'This is an anonymous reply');
+
+		const storedReply = await posts.getPostData(anonymousReply.pid);
+		assert.strictEqual(storedReply.anonymous, 1);
+	});
+
+	it('should handle posts without anonymous field (defaults to 0)', async () => {
+		const regularReply = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is a regular reply',
+		});
+
+		assert(regularReply);
+		assert.strictEqual(regularReply.anonymous, 0);
+		assert.strictEqual(regularReply.uid, testUid);
+		assert.strictEqual(regularReply.content, 'This is a regular reply');
+
+		const storedReply = await posts.getPostData(regularReply.pid);
+		assert.strictEqual(storedReply.anonymous, 0);
+	});
+
+	it('should be able to set and get anonymous field using setPostField', async () => {
+		const testPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Test post for field manipulation',
+		});
+
+		// Default should be 0
+		assert.strictEqual(testPost.anonymous, 0);
+
+		// Set to anonymous
+		await posts.setPostField(testPost.pid, 'anonymous', 1);
+		const updatedPost = await posts.getPostData(testPost.pid);
+		assert.strictEqual(updatedPost.anonymous, 1);
+
+		// Set back to non-anonymous
+		await posts.setPostField(testPost.pid, 'anonymous', 0);
+		const finalPost = await posts.getPostData(testPost.pid);
+		assert.strictEqual(finalPost.anonymous, 0);
+	});
+
+	it('should include anonymous field when getting post fields', async () => {
+		const anonymousPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Test post for field retrieval',
+			anonymous: 1,
+		});
+
+		// Test getting specific fields including anonymous
+		const postFields = await posts.getPostFields(anonymousPost.pid, ['pid', 'uid', 'content', 'anonymous']);
+		assert.strictEqual(postFields.pid, anonymousPost.pid);
+		assert.strictEqual(postFields.uid, testUid);
+		assert.strictEqual(postFields.content, 'Test post for field retrieval');
+		assert.strictEqual(postFields.anonymous, 1);
+
+		// Test getting just the anonymous field
+		const anonymousField = await posts.getPostField(anonymousPost.pid, 'anonymous');
+		assert.strictEqual(anonymousField, 1);
+	});
+
+	it('should handle multiple posts with mixed anonymous status', async () => {
+		const postList = [];
+		
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Regular post 1',
+			anonymous: 0,
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Anonymous post 1',
+			anonymous: 1,
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Regular post 2',
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Anonymous post 2',
+			anonymous: 1,
+		}));
+
+		// Get all posts and verify their anonymous status
+		const pids = postList.map(p => p.pid);
+		const allPosts = await posts.getPostsData(pids);
+
+		assert.strictEqual(allPosts.length, 4);
+		assert.strictEqual(allPosts[0].anonymous, 0);
+		assert.strictEqual(allPosts[1].anonymous, 1);
+		assert.strictEqual(allPosts[2].anonymous, 0);
+		assert.strictEqual(allPosts[3].anonymous, 1);
+	});
+});

--- a/test/upgrades/add-anonymous-field-to-posts.js
+++ b/test/upgrades/add-anonymous-field-to-posts.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const db = require('../mocks/databasemock');
+const posts = require('../../src/posts');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const user = require('../../src/user');
+
+const upgradeScript = require('../../src/upgrades/4.4.0/add-anonymous-field-to-posts');
+
+describe('Upgrade: Add anonymous field to posts', () => {
+	let testUid;
+	let testCid;
+	let topicData;
+	let postData1;
+	let postData2;
+	let postData3;
+
+	before(async () => {
+		// Create test user
+		testUid = await user.create({ username: 'testuser' });
+		
+		// Create test category
+		({ cid: testCid } = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for upgrade testing',
+		}));
+
+		// Create test topic
+		({ topicData, postData: postData1 } = await topics.post({
+			uid: testUid,
+			cid: testCid,
+			title: 'Test Topic for Upgrade',
+			content: 'This is a test topic for upgrade testing',
+		}));
+
+		postData2 = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is a test reply for upgrade testing',
+		});
+
+		postData3 = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is another test reply for upgrade testing',
+		});
+	});
+
+	describe('Pre-upgrade state', () => {
+		it('should have posts without anonymous field', async () => {
+			// Remove anonymous field from posts to simulate pre-upgrade state
+			await db.deleteObjectField(`post:${postData1.pid}`, 'anonymous');
+			await db.deleteObjectField(`post:${postData2.pid}`, 'anonymous');
+			await db.deleteObjectField(`post:${postData3.pid}`, 'anonymous');
+
+			// Check that posts exist but don't have anonymous field
+			const post1 = await db.getObject(`post:${postData1.pid}`);
+			const post2 = await db.getObject(`post:${postData2.pid}`);
+			const post3 = await db.getObject(`post:${postData3.pid}`);
+
+			assert(post1);
+			assert(post2);
+			assert(post3);
+			assert(!post1.hasOwnProperty('anonymous'));
+			assert(!post2.hasOwnProperty('anonymous'));
+			assert(!post3.hasOwnProperty('anonymous'));
+		});
+
+		it('should have posts in the posts:pid sorted set', async () => {
+			const allPids = await db.getSortedSetRange('posts:pid', 0, -1);
+			assert(allPids.length >= 3);
+			assert(allPids.includes(postData1.pid.toString()));
+			assert(allPids.includes(postData2.pid.toString()));
+			assert(allPids.includes(postData3.pid.toString()));
+		});
+	});
+
+	describe('Upgrade script execution', () => {
+		it('should have correct upgrade script metadata', () => {
+			assert.strictEqual(upgradeScript.name, 'Add anonymous field to posts');
+			assert(upgradeScript.timestamp);
+			assert(typeof upgradeScript.method, 'function');
+		});
+
+		it('should run upgrade script without errors', async () => {
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			// Run the upgrade script
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+	});
+
+	describe('Post-upgrade state', () => {
+		it('should add anonymous field to all existing posts', async () => {
+			// Check that all posts now have anonymous field set to 0
+			const post1 = await db.getObject(`post:${postData1.pid}`);
+			const post2 = await db.getObject(`post:${postData2.pid}`);
+			const post3 = await db.getObject(`post:${postData3.pid}`);
+
+			assert(post1);
+			assert(post2);
+			assert(post3);
+			assert(post1.hasOwnProperty('anonymous'));
+			assert(post2.hasOwnProperty('anonymous'));
+			assert(post3.hasOwnProperty('anonymous'));
+			assert.strictEqual(parseInt(post1.anonymous), 0);
+			assert.strictEqual(parseInt(post2.anonymous), 0);
+			assert.strictEqual(parseInt(post3.anonymous), 0);
+		});
+
+		it('should not modify posts that already have anonymous field', async () => {
+			// Create a new post with anonymous field already set
+			const newPost = await posts.create({
+				uid: testUid,
+				tid: topicData.tid,
+				content: 'This post already has anonymous field',
+				anonymous: 1,
+			});
+
+			// Run upgrade again
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+			await upgradeScript.method.bind({ progress: mockProgress })();
+
+			// Check that the post still has anonymous: 1
+			const post = await db.getObject(`post:${newPost.pid}`);
+			assert.strictEqual(parseInt(post.anonymous), 1);
+		});
+
+		it('should handle empty posts:pid set gracefully', async () => {
+			// Clear the posts:pid set
+			await db.delete('posts:pid');
+			
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+
+		it('should handle non-existent post objects gracefully', async () => {
+			// Add a non-existent pid to the posts:pid set
+			await db.sortedSetAdd('posts:pid', Date.now(), '999999');
+			
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+	});
+
+	describe('Batch processing', () => {
+		it('should process posts in batches correctly', async () => {
+			// Create many posts to test batch processing
+			const manyPosts = [];
+			for (let i = 0; i < 10; i++) {
+				const post = await posts.create({
+					uid: testUid,
+					tid: topicData.tid,
+					content: `Batch test post ${i}`,
+				});
+				manyPosts.push(post);
+			}
+
+			// Remove anonymous field from these posts to simulate pre-upgrade state
+			for (const post of manyPosts) {
+				await db.deleteObjectField(`post:${post.pid}`, 'anonymous');
+			}
+
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+			await upgradeScript.method.bind({ progress: mockProgress })();
+
+			// Verify all posts now have anonymous field
+			for (const post of manyPosts) {
+				const postData = await db.getObject(`post:${post.pid}`);
+				assert(postData.hasOwnProperty('anonymous'));
+				assert.strictEqual(parseInt(postData.anonymous), 0);
+			}
+		});
+	});
+
+	describe('Integration with posts module', () => {
+		it('should work with posts.getPostData after upgrade', async () => {
+			const postData = await posts.getPostData(postData1.pid);
+			assert(postData);
+			assert.strictEqual(parseInt(postData.anonymous), 0);
+		});
+
+		it('should work with posts.getPostsData after upgrade', async () => {
+			const postsData = await posts.getPostsData([postData1.pid, postData2.pid, postData3.pid]);
+			assert.strictEqual(postsData.length, 3);
+			postsData.forEach(post => {
+				assert.strictEqual(parseInt(post.anonymous), 0);
+			});
+		});
+
+		it('should work with posts.getPostField after upgrade', async () => {
+			const anonymousField = await posts.getPostField(postData1.pid, 'anonymous');
+			assert.strictEqual(parseInt(anonymousField), 0);
+		});
+	});
+});


### PR DESCRIPTION
**TLDR:**  This PR implements anonymous posts functionality by allowing users to create posts and replies with an `anonymous`
field that defaults to 0 (not-anonymous) and can be set to 1 (anonymous).

**Changes made:**
- Post Creation: Set anonymous field or defaults to 0 if not specified (create.js).
- Post Summary: Added anonymous to the fields array in getPostSummaryByPids.
- DB Schema & Migration: Added database migration to add anonymous field to existing posts with default value of 0 (not anonymous).

**Testing:**
- `npm test -- test/posts/anonymous.js`
- `pm test -- test/upgrades/add-anonymous-field-to-posts.js`

Credits: Tests were initially drafted by Claude AI