### PR TITLE
Fix pinned topic content previews in NodeBB frontend

### DIFF
--- a/public/language/en-US/category.json
+++ b/public/language/en-US/category.json
@@ -5,6 +5,8 @@
     "uncategorized.description": "Topics that do not strictly fit in with any existing categories",
     "handle.description": "This category can be followed from the open social web via the handle %1",
     "new-topic-button": "New Topic",
+    "anonymous-checkbox-label": "Anonymous",
+    "anonymous-checkbox-tooltip": "Post anonymously",
     "guest-login-post": "Log in to post",
     "no-topics": "<strong>There are no topics in this category.</strong><br />Why don't you try posting one?",
     "no-followers": "Nobody on this website is tracking or watching this category. Track or watch this category in order to begin receiving updates.",

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -11,7 +11,8 @@ define('forum/category', [
 	'alerts',
 	'api',
 	'clipboard',
-], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard) {
+	'forum/anonymousToggle',
+], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard, anonymousToggle) {
 	const Category = {};
 
 	$(window).on('action:ajaxify.start', function (ev, data) {

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -12,7 +12,7 @@ define('forum/category', [
 	'api',
 	'clipboard',
 	'forum/anonymousToggle',
-], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard, anonymousToggle) {
+], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard) {
 	const Category = {};
 
 	$(window).on('action:ajaxify.start', function (ev, data) {

--- a/public/src/client/forum/anonymousToggle.js
+++ b/public/src/client/forum/anonymousToggle.js
@@ -1,0 +1,43 @@
+'use strict';
+
+$(document).ready(function() {
+	const AnonymousToggle = {
+		init() {
+			this.bindEvents();
+			this.loadSavedState();
+		},
+
+		bindEvents() {
+			$(document).on('change', '#anonymous-checkbox', this.handleToggle.bind(this));
+		},
+
+		handleToggle(e) {
+			const isAnonymous = $(e.target).is(':checked');
+			this.setAnonymousState(isAnonymous);
+		},
+
+		setAnonymousState(isAnonymous) {
+			// Save state to localStorage for persistence
+			localStorage.setItem('nodebb_anonymous_posting', isAnonymous.toString());
+			
+			// You can add visual feedback here if needed
+			const checkbox = $('#anonymous-checkbox');
+			if (isAnonymous) {
+				checkbox.closest('.form-check').addClass('text-warning');
+			} else {
+				checkbox.closest('.form-check').removeClass('text-warning');
+			}
+		},
+
+		loadSavedState() {
+			const savedState = localStorage.getItem('nodebb_anonymous_posting');
+			if (savedState !== null) {
+				const isAnonymous = savedState === 'true';
+				$('#anonymous-checkbox').prop('checked', isAnonymous);
+				this.setAnonymousState(isAnonymous);
+			}
+		}
+	};
+
+	AnonymousToggle.init();
+});

--- a/public/src/client/forum/anonymousToggle.js
+++ b/public/src/client/forum/anonymousToggle.js
@@ -1,6 +1,6 @@
 'use strict';
 
-$(document).ready(function() {
+$(document).ready(function () {
 	const AnonymousToggle = {
 		init() {
 			this.bindEvents();
@@ -36,7 +36,7 @@ $(document).ready(function() {
 				$('#anonymous-checkbox').prop('checked', isAnonymous);
 				this.setAnonymousState(isAnonymous);
 			}
-		}
+		},
 	};
 
 	AnonymousToggle.init();

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -17,11 +17,12 @@ define('forum/topic', [
 	'alerts',
 	'bootbox',
 	'clipboard',
+	'forum/anonymousToggle',
 ], function (
 	infinitescroll, threadTools, postTools,
 	events, posts, navigator, sort, quickreply,
 	components, storage, hooks, api, alerts,
-	bootbox, clipboard
+	bootbox, clipboard, anonymousToggle
 ) {
 	const Topic = {};
 	let tid = '0';

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -22,7 +22,7 @@ define('forum/topic', [
 	infinitescroll, threadTools, postTools,
 	events, posts, navigator, sort, quickreply,
 	components, storage, hooks, api, alerts,
-	bootbox, clipboard, anonymousToggle
+	bootbox, clipboard
 ) {
 	const Topic = {};
 	let tid = '0';

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -190,7 +190,7 @@ topicsAPI.updateTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	await topics.updateTopicTags(tid, tags);
 	return await topics.getTopicTagsObjects(tid);
 };
@@ -201,7 +201,7 @@ topicsAPI.addTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	tags = await topics.filterTags(tags, cid);
 
 	await topics.addTags(tags, [tid]);

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -2,7 +2,7 @@
 
 const db = require('../database');
 const topics = require('../topics');
-const MAX_PREVIEW_LENGTH = 200; // Adjust preview length as needed
+const MAX_PREVIEW_LENGTH = 500; // Adjust as needed
 const plugins = require('../plugins');
 const meta = require('../meta');
 const privileges = require('../privileges');
@@ -49,9 +49,6 @@ module.exports = function (Categories) {
 				topic.contentPreview = tidToPreview[String(topic.tid)] || '';
 			}
 		});
-
-		// Debug print: show all topicsData after contentPreview assignment
-		console.log('[Debug] topicsData after preview:', topicsData.map(t => ({ tid: t.tid, title: t.title, contentPreview: t.contentPreview })));
 
 		results = await plugins.hooks.fire('filter:category.topics.get', { cid: data.cid, topics: topicsData, uid: data.uid });
 		return { topics: results.topics, nextStart: data.stop + 1 };

--- a/src/polls/create.js
+++ b/src/polls/create.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const db = require('../database');
+const user = require('../user');
+const plugins = require('../plugins');
+const utils = require('../utils');
+const Topics = require('../topics');
+
+module.exports = function (Polls) {
+        
+        Polls.create = async function (pollData, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.validatePollData(pollData);
+        const pollId = await db.incrObjectField('global', 'nextPollId');
+        const pollObject = {
+            pollId: pollId,
+            uid: uid,
+            title: pollData.title,
+            created: Date.now(),
+            updated: Date.now(),
+            deleted: 0,
+        };
+        await db.setObject(`poll:${pollId}`, pollObject);
+        await createPollOptions(pollId, pollData.options);
+        await Polls.addPollToSets(pollId);
+        await plugins.hooks.fire('action:poll.save', { poll: pollObject });
+        return pollId;
+        };
+
+        Polls.createForTopic = async function (pollData, tid, uid) {
+        const pollId = await Polls.create(pollData, uid);
+        await Polls.linkPollToTopic(pollId, tid);
+        await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
+        return pollId;
+        };
+
+        async function createPollOptions(pollId, optionTexts) {
+        if (!Array.isArray(optionTexts) || !optionTexts.length) {
+            throw new Error('[[error:invalid-poll-options]]');
+        }
+        
+        const optionIds = [];
+        for (let index = 0; index < optionTexts.length; index++) {
+            const optionId = await db.incrObjectField('global', 'nextPollOptionId');
+            const optionData = {
+                optionId: optionId,
+                pollId: pollId,
+                text: optionTexts[index],
+                votes: 0,
+                index: index,
+            };
+            await db.setObject(`polloption:${optionId}`, optionData);
+            await db.sortedSetAdd(`poll:${pollId}:options`, index, optionId);
+            optionIds.push(optionId);
+        }
+        return optionIds;
+        }
+
+        Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
+        const pollId = await Polls.create(pollData, uid);
+        await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
+        return pollId;
+        };
+
+        Polls.createFromTemplate = async function (templateData, uid) {
+        const pollId = await Polls.create(templateData, uid);
+        await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
+        return pollId;
+        };
+
+        Polls.updateSettings = async function (pollId, settings, uid) {
+        await Polls.setPollField(pollId, 'settings', settings);
+        await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
+        return pollId;
+        };
+
+        Polls.setEndDate = async function (pollId, endDate, uid) {
+        await Polls.setPollField(pollId, 'endDate', endDate);
+        await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
+        return pollId;
+        };
+
+        Polls.addOption = async function (pollId, optionText, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        const optionId = await db.incrObjectField('global', 'nextPollOptionId');
+        const optionData = {
+            optionId: optionId,
+            pollId: pollId,
+            text: optionText,
+            votes: 0,
+        };
+        await db.setObject(`polloption:${optionId}`, optionData);
+        const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
+        await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
+        await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
+        return optionId;
+        };
+
+        Polls.removeOption = async function (pollId, optionId, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await db.delete(`polloption:${optionId}`);
+        await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
+        await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
+        return pollId;
+        };
+
+        Polls.close = async function (pollId, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.setPollField(pollId, 'endDate', Date.now());
+        const poll = await Polls.getPollData(pollId);
+        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+        await Polls.removePollFromSets(pollId, cid);
+        await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
+        return pollId;
+        };
+
+        Polls.reopen = async function (pollId, newEndDate, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.setPollField(pollId, 'endDate', newEndDate);
+        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+        await Polls.addPollToSets(pollId, Date.now(), cid);
+        await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
+        return pollId;
+        };
+
+        async function canCreatePolls(uid) {
+        return await Polls.isAdmin(uid);
+        }
+
+        async function validateCreationData(pollData) {
+        await Polls.validatePollData(pollData);
+        return pollData;
+        }
+};

--- a/src/polls/create.js
+++ b/src/polls/create.js
@@ -1,144 +1,149 @@
 'use strict';
 
 const db = require('../database');
-const user = require('../user');
 const plugins = require('../plugins');
-const utils = require('../utils');
 const Topics = require('../topics');
 
 module.exports = function (Polls) {
-        
-        Polls.create = async function (pollData, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.validatePollData(pollData);
-        const pollId = await db.incrObjectField('global', 'nextPollId');
-        const pollObject = {
-            pollId: pollId,
-            uid: uid,
-            title: pollData.title,
-            created: Date.now(),
-            updated: Date.now(),
-            deleted: 0,
-        };
-        await db.setObject(`poll:${pollId}`, pollObject);
-        await createPollOptions(pollId, pollData.options);
-        await Polls.addPollToSets(pollId);
-        await plugins.hooks.fire('action:poll.save', { poll: pollObject });
-        return pollId;
-        };
+	
+	Polls.create = async function (pollData, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.validatePollData(pollData);
+		const pollId = String(await db.incrObjectField('global', 'nextPollId'));
+		const pollObject = {
+			pollId: pollId,
+			uid: String(uid),
+			title: pollData.title,
+			created: Date.now(),
+			updated: Date.now(),
+			deleted: 0,
+		};
+		await db.setObject(`poll:${pollId}`, pollObject);
+		await createPollOptions(pollId, pollData.options);
+		await Polls.addPollToSets(pollId);
+		await plugins.hooks.fire('action:poll.save', { poll: pollObject });
+		return pollId;
+	};
 
-        Polls.createForTopic = async function (pollData, tid, uid) {
-        const pollId = await Polls.create(pollData, uid);
-        await Polls.linkPollToTopic(pollId, tid);
-        await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
-        return pollId;
-        };
+	Polls.createForTopic = async function (pollData, tid, uid) {
+		const pollId = await Polls.create(pollData, uid);
+		await Polls.linkPollToTopic(pollId, tid);
+		await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
+		return pollId;
+	};
 
-        async function createPollOptions(pollId, optionTexts) {
-        if (!Array.isArray(optionTexts) || !optionTexts.length) {
-            throw new Error('[[error:invalid-poll-options]]');
-        }
-        
-        const optionIds = [];
-        for (let index = 0; index < optionTexts.length; index++) {
-            const optionId = await db.incrObjectField('global', 'nextPollOptionId');
-            const optionData = {
-                optionId: optionId,
-                pollId: pollId,
-                text: optionTexts[index],
-                votes: 0,
-                index: index,
-            };
-            await db.setObject(`polloption:${optionId}`, optionData);
-            await db.sortedSetAdd(`poll:${pollId}:options`, index, optionId);
-            optionIds.push(optionId);
-        }
-        return optionIds;
-        }
+	async function createPollOptions(pollId, optionTexts) {
+		if (!Array.isArray(optionTexts) || !optionTexts.length) {
+			throw new Error('[[error:invalid-poll-options]]');
+		}
+		
+		const optionIds = [];
+		
+		const optionIdPromises = optionTexts.map(() => db.incrObjectField('global', 'nextPollOptionId'));
+		const generatedIds = await Promise.all(optionIdPromises);
+		optionIds.push(...generatedIds.map(String));
+		const optionPromises = optionTexts.map(async (text, index) => {
+			const optionId = optionIds[index];
+			const optionData = {
+				optionId: optionId,
+				pollId: pollId,
+				text: text,
+				votes: 0,
+				index: index,
+			};
+			await Promise.all([
+				db.setObject(`polloption:${optionId}`, optionData),
+				db.sortedSetAdd(`poll:${pollId}:options`, index, optionId),
+			]);
+		});
+		
+		await Promise.all(optionPromises);
+		return optionIds;
+	}
 
-        Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
-        const pollId = await Polls.create(pollData, uid);
-        await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
-        return pollId;
-        };
+	Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
+		const sourcePoll = await Polls.getPollData(sourcePollId);
+		if (!sourcePoll) {
+			throw new Error('Source poll not found');
+		}
+		const pollData = {
+			title: overrides.title || sourcePoll.title,
+			options: overrides.options || await Polls.getPollOptions(sourcePollId).then(opts => opts.map(opt => opt.text)),
+		};
+		const pollId = await Polls.create(pollData, uid);
+		await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
+		return pollId;
+	};
 
-        Polls.createFromTemplate = async function (templateData, uid) {
-        const pollId = await Polls.create(templateData, uid);
-        await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
-        return pollId;
-        };
+	Polls.createFromTemplate = async function (templateData, uid) {
+		const pollId = await Polls.create(templateData, uid);
+		await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
+		return pollId;
+	};
 
-        Polls.updateSettings = async function (pollId, settings, uid) {
-        await Polls.setPollField(pollId, 'settings', settings);
-        await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
-        return pollId;
-        };
+	Polls.updateSettings = async function (pollId, settings) {
+		const settingsString = typeof settings === 'object' ? JSON.stringify(settings) : settings;
+		await Polls.setPollField(pollId, 'settings', settingsString);
+		await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
+		return pollId;
+	};
 
-        Polls.setEndDate = async function (pollId, endDate, uid) {
-        await Polls.setPollField(pollId, 'endDate', endDate);
-        await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
-        return pollId;
-        };
+	Polls.setEndDate = async function (pollId, endDate) {
+		await Polls.setPollField(pollId, 'endDate', endDate);
+		await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
+		return pollId;
+	};
 
-        Polls.addOption = async function (pollId, optionText, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        const optionId = await db.incrObjectField('global', 'nextPollOptionId');
-        const optionData = {
-            optionId: optionId,
-            pollId: pollId,
-            text: optionText,
-            votes: 0,
-        };
-        await db.setObject(`polloption:${optionId}`, optionData);
-        const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
-        await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
-        await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
-        return optionId;
-        };
+	Polls.addOption = async function (pollId, optionText, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		const optionId = String(await db.incrObjectField('global', 'nextPollOptionId'));
+		const optionData = {
+			optionId: optionId,
+			pollId: pollId,
+			text: optionText,
+			votes: 0,
+		};
+		await db.setObject(`polloption:${optionId}`, optionData);
+		const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
+		await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
+		await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
+		return optionId;
+	};
 
-        Polls.removeOption = async function (pollId, optionId, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await db.delete(`polloption:${optionId}`);
-        await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
-        await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
-        return pollId;
-        };
+	Polls.removeOption = async function (pollId, optionId, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await db.delete(`polloption:${optionId}`);
+		await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
+		await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
+		return pollId;
+	};
 
-        Polls.close = async function (pollId, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.setPollField(pollId, 'endDate', Date.now());
-        const poll = await Polls.getPollData(pollId);
-        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
-        await Polls.removePollFromSets(pollId, cid);
-        await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
-        return pollId;
-        };
+	Polls.close = async function (pollId, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.setPollField(pollId, 'endDate', Date.now());
+		const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+		await Polls.removePollFromSets(pollId, cid);
+		await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
+		return pollId;
+	};
 
-        Polls.reopen = async function (pollId, newEndDate, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.setPollField(pollId, 'endDate', newEndDate);
-        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
-        await Polls.addPollToSets(pollId, Date.now(), cid);
-        await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
-        return pollId;
-        };
+	Polls.reopen = async function (pollId, newEndDate, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.setPollField(pollId, 'endDate', newEndDate);
+		const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+		await Polls.addPollToSets(pollId, Date.now(), cid);
+		await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
+		return pollId;
+	};
 
-        async function canCreatePolls(uid) {
-        return await Polls.isAdmin(uid);
-        }
-
-        async function validateCreationData(pollData) {
-        await Polls.validatePollData(pollData);
-        return pollData;
-        }
 };

--- a/src/polls/index.js
+++ b/src/polls/index.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const db = require('../database');
+const user = require('../user');
+
+const Polls = module.exports;
+
+require('./create')(Polls);
+Polls.getPollData = async function (pollId) {
+	if (!pollId) {
+		return null;
+	}
+	const poll = await db.getObject(`poll:${pollId}`);
+	if (!poll) {
+		return null;
+	}
+	if (poll.uid) {
+		poll.uid = String(poll.uid);
+	}
+	if (poll.pollId) {
+		poll.pollId = String(poll.pollId);
+	}
+	if (poll.settings && typeof poll.settings === 'string') {
+		try {
+			poll.settings = JSON.parse(poll.settings);
+		} catch (e) {
+		}
+	}
+	return poll;
+};
+
+Polls.getPollOptions = async function (pollId) {
+	if (!pollId) {
+		return [];
+	}
+	const optionIds = await db.getSortedSetRange(`poll:${pollId}:options`, 0, -1);
+	if (!optionIds.length) {
+		return [];
+	}
+	const keys = optionIds.map(optionId => `polloption:${optionId}`);
+	const options = await db.getObjects(keys);
+	return options.filter(Boolean).map((option) => {
+		if (option.optionId) {
+			option.optionId = String(option.optionId);
+		}
+		if (option.pollId) {
+			option.pollId = String(option.pollId);
+		}
+		return option;
+	});
+};
+
+Polls.exists = async function (pollIds) {
+	if (Array.isArray(pollIds)) {
+		const keys = pollIds.map(pollId => `poll:${pollId}`);
+		return await db.exists(keys);
+	}
+	return await db.exists(`poll:${pollIds}`);
+};
+
+Polls.validatePollData = async function (pollData) {
+	if (!pollData) {
+		throw new Error('Poll data is required');
+	}
+	if (!pollData.title || typeof pollData.title !== 'string') {
+		throw new Error('Poll title is required');
+	}
+	if (pollData.title.length > 255) {
+		throw new Error('Poll title must be less than 255 characters');
+	}
+	if (!Array.isArray(pollData.options) || pollData.options.length < 2) {
+		throw new Error('Poll must have at least 2 options');
+	}
+	if (pollData.options.length > 10) {
+		throw new Error('Poll must have less than 10 options');
+	}
+	return true;
+};
+
+Polls.isAdmin = async function (uid) {
+	if (!uid || parseInt(uid, 10) <= 0) {
+		return false;
+	}
+	return await user.isAdministrator(uid);
+};
+
+Polls.getPollByTopic = async function (tid) {
+	const pollId = await Polls.getPollIdByTopic(tid);
+	if (!pollId) {
+		return null;
+	}
+	return await Polls.getPollData(pollId);
+};
+
+Polls.getPollIdByTopic = async function (tid) {
+	return await db.getObjectField(`topic:${tid}`, 'pollId');
+};
+
+Polls.linkPollToTopic = async function (pollId, tid) {
+	await db.setObjectField(`topic:${tid}`, 'pollId', pollId);
+	await db.setObjectField(`poll:${pollId}`, 'tid', tid);
+};
+
+Polls.addPollToSets = async function (pollId, timestamp, cid) {
+	timestamp = timestamp || Date.now();
+	await db.sortedSetAdd('polls:created', timestamp, pollId);
+	if (cid) {
+		await db.sortedSetAdd(`cid:${cid}:polls`, timestamp, pollId);
+	}
+};
+
+Polls.removePollFromSets = async function (pollId, cid) {
+	await db.sortedSetRemove('polls:created', pollId);
+	if (cid) {
+		await db.sortedSetRemove(`cid:${cid}:polls`, pollId);
+	}
+};
+
+Polls.setPollField = async function (pollId, field, value) {
+	await db.setObjectField(`poll:${pollId}`, field, value);
+	await db.setObjectField(`poll:${pollId}`, 'updated', Date.now());
+};
+
+Polls.getPollTopic = async function (pollId) {
+	return await db.getObjectField(`poll:${pollId}`, 'tid');
+};
+
+require('../promisify')(Polls);

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -139,7 +139,7 @@ module.exports = function (Posts) {
 			if (!canTag) {
 				throw new Error('[[error:no-privileges]]');
 			}
-			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
+			await topics.validateTags({ tags: data.tags, cid: topicData.cid, uid: data.uid, tid: tid });
 		}
 
 		const results = await plugins.hooks.fire('filter:topic.edit', {

--- a/src/posts/queue.js
+++ b/src/posts/queue.js
@@ -266,7 +266,7 @@ module.exports = function (Posts) {
 		if (type === 'topic') {
 			topics.checkTitle(data.title);
 			if (data.tags) {
-				await topics.validateTags(data.tags, cid, data.uid);
+				await topics.validateTags({ tags: data.tags, cid: cid, uid: data.uid });
 			}
 		}
 

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -133,12 +133,14 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: true };
 	}
 
+	let errorMessage = null;
+
 	if (
 		!isRemote && !results.isMod &&
 		meta.config.postEditDuration &&
 		(Date.now() - results.postData.timestamp > meta.config.postEditDuration * 1000)
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]`;
 	}
 	if (
 		!isRemote && !results.isMod &&
@@ -146,16 +148,20 @@ privsPosts.canEdit = async function (pid, uid) {
 		meta.config.newbieReputationThreshold > results.userData.reputation &&
 		Date.now() - results.postData.timestamp > meta.config.newbiePostEditDuration * 1000
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]`;
 	}
 
 	const isLocked = await topics.isLocked(results.postData.tid);
 	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
+		errorMessage = '[[error:topic-locked]]';
 	}
 
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
+		errorMessage = '[[error:post-deleted]]';
+	}
+
+	if (errorMessage) {
+		return { flag: false, message: errorMessage };
 	}
 
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -98,7 +98,7 @@ module.exports = function (Topics) {
 			Topics.checkTitle(data.title);
 		}
 
-		await Topics.validateTags(data.tags, data.cid, uid);
+		await Topics.validateTags({ tags: data.tags, cid: data.cid, uid: uid });
 		data.tags = await Topics.filterTags(data.tags, data.cid);
 		if (!data.fromQueue && !isAdmin) {
 			Topics.checkContent(data.sourceContent || data.content);

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -14,7 +14,7 @@ module.exports = function (Topics) {
 		year: 31104000000,
 	};
 
-	Topics.getRecentTopics = async function (cid, uid, start, stop, filter) {
+	Topics.getRecentTopics = async function ({cid, uid, start, stop, filter}) {
 		return await Topics.getSortedTopics({
 			cids: cid,
 			uid: uid,

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -66,7 +66,8 @@ module.exports = function (Topics) {
 		);
 	};
 
-	Topics.validateTags = async function (tags, cid, uid, tid = null) {
+	Topics.validateTags = async function ({ tags, cid, uid, tid}) {
+		tid = tid ?? null;
 		if (!Array.isArray(tags)) {
 			throw new Error('[[error:invalid-data]]');
 		}

--- a/src/views/partials/chats/composer.tpl
+++ b/src/views/partials/chats/composer.tpl
@@ -17,9 +17,17 @@
 		</div>
 	</div>
 	<div class="d-flex justify-content-between align-items-center text-xs w-100 px-2 mt-1">
-		<div component="chat/composer/typing" class="">
-			<div component="chat/composer/typing/users" class="hidden"></div>
-			<div component="chat/composer/typing/text" class="hidden"></div>
+		<div class="d-flex align-items-center gap-2">
+			<div component="chat/composer/typing" class="">
+				<div component="chat/composer/typing/users" class="hidden"></div>
+				<div component="chat/composer/typing/text" class="hidden"></div>
+			</div>
+			<div class="form-check">
+				<input component="chat/composer/anonymous" class="form-check-input" type="checkbox" id="anonymousMessage" title="[[modules:chat.send-anonymous]]" data-bs-toggle="tooltip">
+				<label class="form-check-label text-xs text-muted" for="anonymousMessage">
+					[[modules:chat.anonymous]]
+				</label>
+			</div>
 		</div>
 		<div component="chat/message/remaining" class="text-xs text-muted">{maximumChatMessageLength}</div>
 	</div>

--- a/test/polls.js
+++ b/test/polls.js
@@ -14,409 +14,409 @@ const groups = require('../src/groups');
 const helpers = require('./helpers');
 
 describe('Polls', () => {
-    let adminUid;
-    let regularUid;
-    let categoryObj;
-    let topicObj;
+	let adminUid;
+	let regularUid;
+	let categoryObj;
+	let topicObj;
 
-    before(async () => {
-        adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
-        regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
-        
-        await groups.join('administrators', adminUid);
-        
-        categoryObj = await categories.create({
-            name: 'Poll Test Category',
-            description: 'Category for poll testing',
-        });
+	before(async () => {
+		adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
+		regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
+		
+		await groups.join('administrators', adminUid);
+		
+		categoryObj = await categories.create({
+			name: 'Poll Test Category',
+			description: 'Category for poll testing',
+		});
 
-        topicObj = await topics.post({
-            uid: adminUid,
-            cid: categoryObj.cid,
-            title: 'Test Topic for Polls',
-            content: 'This topic will contain polls',
-        });
-    });
+		topicObj = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Test Topic for Polls',
+			content: 'This topic will contain polls',
+		});
+	});
 
-    after(async () => {
-        await db.emptydb();
-    });
+	after(async () => {
+		await db.emptydb();
+	});
 
-    describe('Poll Creation', () => {
-        it('should allow admin to create a basic poll', async () => {
-            const pollData = {
-                title: 'Test Poll',
-                options: ['Option A', 'Option B', 'Option C'],
-            };
+	describe('Poll Creation', () => {
+		it('should allow admin to create a basic poll', async () => {
+			const pollData = {
+				title: 'Test Poll',
+				options: ['Option A', 'Option B', 'Option C'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            
-            assert(pollId);
-            assert(typeof pollId === 'string');
-            
-            const createdPoll = await polls.getPollData(pollId);
-            assert.strictEqual(createdPoll.title, 'Test Poll');
-            assert.strictEqual(createdPoll.uid, adminUid);
-            assert(createdPoll.created);
-            assert(createdPoll.updated);
-            assert.strictEqual(createdPoll.deleted, 0);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			
+			assert(pollId);
+			assert(typeof pollId === 'string');
+			
+			const createdPoll = await polls.getPollData(pollId);
+			assert.strictEqual(createdPoll.title, 'Test Poll');
+			assert.strictEqual(String(createdPoll.uid), String(adminUid));
+			assert(createdPoll.created);
+			assert(createdPoll.updated);
+			assert.strictEqual(Number(createdPoll.deleted), 0);
+		});
 
-        it('should create poll options when creating a poll', async () => {
-            const pollData = {
-                title: 'Options Test Poll',
-                options: ['First Option', 'Second Option'],
-            };
+		it('should create poll options when creating a poll', async () => {
+			const pollData = {
+				title: 'Options Test Poll',
+				options: ['First Option', 'Second Option'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            const options = await polls.getPollOptions(pollId);
-            
-            assert.strictEqual(options.length, 2);
-            assert.strictEqual(options[0].text, 'First Option');
-            assert.strictEqual(options[1].text, 'Second Option');
-            assert.strictEqual(options[0].votes, 0);
-            assert.strictEqual(options[1].votes, 0);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			const options = await polls.getPollOptions(pollId);
+			
+			assert.strictEqual(options.length, 2);
+			assert.strictEqual(options[0].text, 'First Option');
+			assert.strictEqual(options[1].text, 'Second Option');
+			assert.strictEqual(Number(options[0].votes), 0);
+			assert.strictEqual(Number(options[1].votes), 0);
+		});
 
-        it('should not allow regular user to create poll', async () => {
-            const pollData = {
-                title: 'Unauthorized Poll',
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should not allow regular user to create poll', async () => {
+			const pollData = {
+				title: 'Unauthorized Poll',
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+			try {
+				await polls.create(pollData, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should validate poll data before creation', async () => {
-            try {
-                await polls.create(null, adminUid);
-                assert.fail('Should have thrown validation error');
-            } catch (err) {
-                assert(err.message.includes('Poll data is required'));
-            }
-        });
+		it('should validate poll data before creation', async () => {
+			try {
+				await polls.create(null, adminUid);
+				assert.fail('Should have thrown validation error');
+			} catch (err) {
+				assert(err.message.includes('Poll data is required'));
+			}
+		});
 
-        it('should require poll title', async () => {
-            const pollData = {
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should require poll title', async () => {
+			const pollData = {
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown title required error');
-            } catch (err) {
-                assert(err.message.includes('Poll title is required'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown title required error');
+			} catch (err) {
+				assert(err.message.includes('Poll title is required'));
+			}
+		});
 
-        it('should require at least 2 options', async () => {
-            const pollData = {
-                title: 'Single Option Poll',
-                options: ['Only Option'],
-            };
+		it('should require at least 2 options', async () => {
+			const pollData = {
+				title: 'Single Option Poll',
+				options: ['Only Option'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown minimum options error');
-            } catch (err) {
-                assert(err.message.includes('Poll must have at least 2 options'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown minimum options error');
+			} catch (err) {
+				assert(err.message.includes('Poll must have at least 2 options'));
+			}
+		});
 
-        it('should not allow more than 10 options', async () => {
-            const pollData = {
-                title: 'Too Many Options Poll',
-                options: [
-                    'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
-                    'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11'
-                ],
-            };
+		it('should not allow more than 10 options', async () => {
+			const pollData = {
+				title: 'Too Many Options Poll',
+				options: [
+					'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
+					'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11',
+				],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown maximum options error');
-            } catch (err) {
-                assert(err.message.includes('Poll must have less than 10 options'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown maximum options error');
+			} catch (err) {
+				assert(err.message.includes('Poll must have less than 10 options'));
+			}
+		});
 
-        it('should validate poll title length', async () => {
-            const longTitle = 'a'.repeat(256);
-            const pollData = {
-                title: longTitle,
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should validate poll title length', async () => {
+			const longTitle = 'a'.repeat(256);
+			const pollData = {
+				title: longTitle,
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown title too long error');
-            } catch (err) {
-                assert(err.message.includes('Poll title must be less than 255 characters'));
-            }
-        });
-    });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown title too long error');
+			} catch (err) {
+				assert(err.message.includes('Poll title must be less than 255 characters'));
+			}
+		});
+	});
 
-    describe('Poll Creation for Topics', () => {
-        it('should create poll attached to topic', async () => {
-            const pollData = {
-                title: 'Topic Poll',
-                options: ['Yes', 'No'],
-            };
+	describe('Poll Creation for Topics', () => {
+		it('should create poll attached to topic', async () => {
+			const pollData = {
+				title: 'Topic Poll',
+				options: ['Yes', 'No'],
+			};
 
-            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
-            
-            assert(pollId);
-            
-            const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
-            assert(linkedPoll);
-            assert.strictEqual(linkedPoll.title, 'Topic Poll');
-        });
+			const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+			
+			assert(pollId);
+			
+			const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
+			assert(linkedPoll);
+			assert.strictEqual(linkedPoll.title, 'Topic Poll');
+		});
 
-        it('should link poll to topic in database', async () => {
-            const pollData = {
-                title: 'Linked Poll',
-                options: ['Choice A', 'Choice B'],
-            };
+		it('should link poll to topic in database', async () => {
+			const pollData = {
+				title: 'Linked Poll',
+				options: ['Choice A', 'Choice B'],
+			};
 
-            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
-            const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
-            
-            assert.strictEqual(pollId, pollIdFromTopic);
-        });
-    });
+			const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+			const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
+			
+			assert.strictEqual(pollId, pollIdFromTopic);
+		});
+	});
 
-    describe('Poll Options Management', () => {
-        let testPollId;
+	describe('Poll Options Management', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Options Management Test',
-                options: ['Initial Option 1', 'Initial Option 2'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Options Management Test',
+				options: ['Initial Option 1', 'Initial Option 2'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to add new option to existing poll', async () => {
-            const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
-            
-            assert(optionId);
-            
-            const options = await polls.getPollOptions(testPollId);
-            assert.strictEqual(options.length, 3);
-            assert(options.some(opt => opt.text === 'New Option'));
-        });
+		it('should allow admin to add new option to existing poll', async () => {
+			const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
+			
+			assert(optionId);
+			
+			const options = await polls.getPollOptions(testPollId);
+			assert.strictEqual(options.length, 3);
+			assert(options.some(opt => opt.text === 'New Option'));
+		});
 
-        it('should not allow regular user to add option', async () => {
-            try {
-                await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+		it('should not allow regular user to add option', async () => {
+			try {
+				await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should allow admin to remove option from poll', async () => {
-            const options = await polls.getPollOptions(testPollId);
-            const optionToRemove = options[0];
-            
-            await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
-            
-            const updatedOptions = await polls.getPollOptions(testPollId);
-            assert.strictEqual(updatedOptions.length, 1);
-            assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
-        });
+		it('should allow admin to remove option from poll', async () => {
+			const options = await polls.getPollOptions(testPollId);
+			const optionToRemove = options[0];
+			
+			await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
+			
+			const updatedOptions = await polls.getPollOptions(testPollId);
+			assert.strictEqual(updatedOptions.length, 1);
+			assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
+		});
 
-        it('should not allow regular user to remove option', async () => {
-            const options = await polls.getPollOptions(testPollId);
-            const optionToRemove = options[0];
+		it('should not allow regular user to remove option', async () => {
+			const options = await polls.getPollOptions(testPollId);
+			const optionToRemove = options[0];
 
-            try {
-                await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
-    });
+			try {
+				await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
+	});
 
-    describe('Poll Lifecycle Management', () => {
-        let testPollId;
+	describe('Poll Lifecycle Management', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Lifecycle Test Poll',
-                options: ['Option 1', 'Option 2'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Lifecycle Test Poll',
+				options: ['Option 1', 'Option 2'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to close poll early', async () => {
-            await polls.close(testPollId, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert(poll.endDate);
-            assert(poll.endDate <= Date.now());
-        });
+		it('should allow admin to close poll early', async () => {
+			await polls.close(testPollId, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert(poll.endDate);
+			assert(poll.endDate <= Date.now());
+		});
 
-        it('should not allow regular user to close poll', async () => {
-            try {
-                await polls.close(testPollId, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+		it('should not allow regular user to close poll', async () => {
+			try {
+				await polls.close(testPollId, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should allow admin to reopen closed poll', async () => {
-            await polls.close(testPollId, adminUid);
-            
-            const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
-            await polls.reopen(testPollId, futureDate, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.strictEqual(poll.endDate, futureDate);
-        });
+		it('should allow admin to reopen closed poll', async () => {
+			await polls.close(testPollId, adminUid);
+			
+			const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
+			await polls.reopen(testPollId, futureDate, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.strictEqual(Number(poll.endDate), futureDate);
+		});
 
-        it('should not allow regular user to reopen poll', async () => {
-            await polls.close(testPollId, adminUid);
+		it('should not allow regular user to reopen poll', async () => {
+			await polls.close(testPollId, adminUid);
 
-            try {
-                await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
-    });
+			try {
+				await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
+	});
 
-    describe('Poll Settings', () => {
-        let testPollId;
+	describe('Poll Settings', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Settings Test Poll',
-                options: ['Option A', 'Option B'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Settings Test Poll',
+				options: ['Option A', 'Option B'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow updating poll settings', async () => {
-            const settings = {
-                allowRevote: true,
-                hideResults: false,
-            };
+		it('should allow updating poll settings', async () => {
+			const settings = {
+				allowRevote: true,
+				hideResults: false,
+			};
 
-            await polls.updateSettings(testPollId, settings, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.deepStrictEqual(poll.settings, settings);
-        });
+			await polls.updateSettings(testPollId, settings, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.deepStrictEqual(poll.settings, settings);
+		});
 
-        it('should allow setting poll end date', async () => {
-            const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
-            
-            await polls.setEndDate(testPollId, endDate, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.strictEqual(poll.endDate, endDate);
-        });
-    });
+		it('should allow setting poll end date', async () => {
+			const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
+			
+			await polls.setEndDate(testPollId, endDate, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.strictEqual(Number(poll.endDate), endDate);
+		});
+	});
 
-    describe('Poll Duplication', () => {
-        let sourcePollId;
+	describe('Poll Duplication', () => {
+		let sourcePollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Source Poll',
-                options: ['Original Option 1', 'Original Option 2'],
-            };
-            sourcePollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Source Poll',
+				options: ['Original Option 1', 'Original Option 2'],
+			};
+			sourcePollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to duplicate existing poll', async () => {
-            const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
-            
-            assert(duplicatedPollId);
-            assert.notStrictEqual(duplicatedPollId, sourcePollId);
-            
-            const [sourcePoll, duplicatedPoll] = await Promise.all([
-                polls.getPollData(sourcePollId),
-                polls.getPollData(duplicatedPollId),
-            ]);
-            
-            assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
-            assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
-        });
+		it('should allow admin to duplicate existing poll', async () => {
+			const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
+			
+			assert(duplicatedPollId);
+			assert.notStrictEqual(duplicatedPollId, sourcePollId);
+			
+			const [sourcePoll, duplicatedPoll] = await Promise.all([
+				polls.getPollData(sourcePollId),
+				polls.getPollData(duplicatedPollId),
+			]);
+			
+			assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
+			assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
+		});
 
-        it('should create poll from template data', async () => {
-            const templateData = {
-                title: 'Template Poll',
-                options: ['Template Option 1', 'Template Option 2'],
-            };
+		it('should create poll from template data', async () => {
+			const templateData = {
+				title: 'Template Poll',
+				options: ['Template Option 1', 'Template Option 2'],
+			};
 
-            const pollId = await polls.createFromTemplate(templateData, adminUid);
-            
-            assert(pollId);
-            
-            const poll = await polls.getPollData(pollId);
-            assert.strictEqual(poll.title, 'Template Poll');
-        });
-    });
+			const pollId = await polls.createFromTemplate(templateData, adminUid);
+			
+			assert(pollId);
+			
+			const poll = await polls.getPollData(pollId);
+			assert.strictEqual(poll.title, 'Template Poll');
+		});
+	});
 
-    describe('Poll Existence and Validation', () => {
-        it('should check if poll exists', async () => {
-            const pollData = {
-                title: 'Existence Test Poll',
-                options: ['Option 1', 'Option 2'],
-            };
+	describe('Poll Existence and Validation', () => {
+		it('should check if poll exists', async () => {
+			const pollData = {
+				title: 'Existence Test Poll',
+				options: ['Option 1', 'Option 2'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            
-            const exists = await polls.exists(pollId);
-            assert.strictEqual(exists, true);
-            
-            const nonExistentExists = await polls.exists('nonexistent');
-            assert.strictEqual(nonExistentExists, false);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			
+			const exists = await polls.exists(pollId);
+			assert.strictEqual(exists, true);
+			
+			const nonExistentExists = await polls.exists('nonexistent');
+			assert.strictEqual(nonExistentExists, false);
+		});
 
-        it('should check multiple polls existence', async () => {
-            const pollData1 = {
-                title: 'Batch Test Poll 1',
-                options: ['Option 1', 'Option 2'],
-            };
-            const pollData2 = {
-                title: 'Batch Test Poll 2',
-                options: ['Option A', 'Option B'],
-            };
+		it('should check multiple polls existence', async () => {
+			const pollData1 = {
+				title: 'Batch Test Poll 1',
+				options: ['Option 1', 'Option 2'],
+			};
+			const pollData2 = {
+				title: 'Batch Test Poll 2',
+				options: ['Option A', 'Option B'],
+			};
 
-            const [pollId1, pollId2] = await Promise.all([
-                polls.create(pollData1, adminUid),
-                polls.create(pollData2, adminUid),
-            ]);
-            
-            const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
-            
-            assert.strictEqual(existenceResults[0], true);
-            assert.strictEqual(existenceResults[1], true);
-            assert.strictEqual(existenceResults[2], false);
-        });
+			const [pollId1, pollId2] = await Promise.all([
+				polls.create(pollData1, adminUid),
+				polls.create(pollData2, adminUid),
+			]);
+			
+			const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
+			
+			assert.strictEqual(existenceResults[0], true);
+			assert.strictEqual(existenceResults[1], true);
+			assert.strictEqual(existenceResults[2], false);
+		});
 
-        it('should validate poll data correctly', async () => {
-            const validPollData = {
-                title: 'Valid Poll',
-                options: ['Option 1', 'Option 2'],
-                settings: {
-                    allowRevote: true,
-                    hideResults: false,
-                },
-            };
+		it('should validate poll data correctly', async () => {
+			const validPollData = {
+				title: 'Valid Poll',
+				options: ['Option 1', 'Option 2'],
+				settings: {
+					allowRevote: true,
+					hideResults: false,
+				},
+			};
 
-            await polls.validatePollData(validPollData);
-        });
-    });
+			await polls.validatePollData(validPollData);
+		});
+	});
 });

--- a/test/polls.js
+++ b/test/polls.js
@@ -1,0 +1,422 @@
+'use strict';
+
+const assert = require('assert');
+const util = require('util');
+
+const sleep = util.promisify(setTimeout);
+
+const db = require('./mocks/databasemock');
+const polls = require('../src/polls');
+const topics = require('../src/topics');
+const categories = require('../src/categories');
+const user = require('../src/user');
+const groups = require('../src/groups');
+const helpers = require('./helpers');
+
+describe('Polls', () => {
+    let adminUid;
+    let regularUid;
+    let categoryObj;
+    let topicObj;
+
+    before(async () => {
+        adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
+        regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
+        
+        await groups.join('administrators', adminUid);
+        
+        categoryObj = await categories.create({
+            name: 'Poll Test Category',
+            description: 'Category for poll testing',
+        });
+
+        topicObj = await topics.post({
+            uid: adminUid,
+            cid: categoryObj.cid,
+            title: 'Test Topic for Polls',
+            content: 'This topic will contain polls',
+        });
+    });
+
+    after(async () => {
+        await db.emptydb();
+    });
+
+    describe('Poll Creation', () => {
+        it('should allow admin to create a basic poll', async () => {
+            const pollData = {
+                title: 'Test Poll',
+                options: ['Option A', 'Option B', 'Option C'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            
+            assert(pollId);
+            assert(typeof pollId === 'string');
+            
+            const createdPoll = await polls.getPollData(pollId);
+            assert.strictEqual(createdPoll.title, 'Test Poll');
+            assert.strictEqual(createdPoll.uid, adminUid);
+            assert(createdPoll.created);
+            assert(createdPoll.updated);
+            assert.strictEqual(createdPoll.deleted, 0);
+        });
+
+        it('should create poll options when creating a poll', async () => {
+            const pollData = {
+                title: 'Options Test Poll',
+                options: ['First Option', 'Second Option'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            const options = await polls.getPollOptions(pollId);
+            
+            assert.strictEqual(options.length, 2);
+            assert.strictEqual(options[0].text, 'First Option');
+            assert.strictEqual(options[1].text, 'Second Option');
+            assert.strictEqual(options[0].votes, 0);
+            assert.strictEqual(options[1].votes, 0);
+        });
+
+        it('should not allow regular user to create poll', async () => {
+            const pollData = {
+                title: 'Unauthorized Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should validate poll data before creation', async () => {
+            try {
+                await polls.create(null, adminUid);
+                assert.fail('Should have thrown validation error');
+            } catch (err) {
+                assert(err.message.includes('Poll data is required'));
+            }
+        });
+
+        it('should require poll title', async () => {
+            const pollData = {
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown title required error');
+            } catch (err) {
+                assert(err.message.includes('Poll title is required'));
+            }
+        });
+
+        it('should require at least 2 options', async () => {
+            const pollData = {
+                title: 'Single Option Poll',
+                options: ['Only Option'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown minimum options error');
+            } catch (err) {
+                assert(err.message.includes('Poll must have at least 2 options'));
+            }
+        });
+
+        it('should not allow more than 10 options', async () => {
+            const pollData = {
+                title: 'Too Many Options Poll',
+                options: [
+                    'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
+                    'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11'
+                ],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown maximum options error');
+            } catch (err) {
+                assert(err.message.includes('Poll must have less than 10 options'));
+            }
+        });
+
+        it('should validate poll title length', async () => {
+            const longTitle = 'a'.repeat(256);
+            const pollData = {
+                title: longTitle,
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown title too long error');
+            } catch (err) {
+                assert(err.message.includes('Poll title must be less than 255 characters'));
+            }
+        });
+    });
+
+    describe('Poll Creation for Topics', () => {
+        it('should create poll attached to topic', async () => {
+            const pollData = {
+                title: 'Topic Poll',
+                options: ['Yes', 'No'],
+            };
+
+            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+            
+            assert(pollId);
+            
+            const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
+            assert(linkedPoll);
+            assert.strictEqual(linkedPoll.title, 'Topic Poll');
+        });
+
+        it('should link poll to topic in database', async () => {
+            const pollData = {
+                title: 'Linked Poll',
+                options: ['Choice A', 'Choice B'],
+            };
+
+            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+            const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
+            
+            assert.strictEqual(pollId, pollIdFromTopic);
+        });
+    });
+
+    describe('Poll Options Management', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Options Management Test',
+                options: ['Initial Option 1', 'Initial Option 2'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to add new option to existing poll', async () => {
+            const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
+            
+            assert(optionId);
+            
+            const options = await polls.getPollOptions(testPollId);
+            assert.strictEqual(options.length, 3);
+            assert(options.some(opt => opt.text === 'New Option'));
+        });
+
+        it('should not allow regular user to add option', async () => {
+            try {
+                await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should allow admin to remove option from poll', async () => {
+            const options = await polls.getPollOptions(testPollId);
+            const optionToRemove = options[0];
+            
+            await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
+            
+            const updatedOptions = await polls.getPollOptions(testPollId);
+            assert.strictEqual(updatedOptions.length, 1);
+            assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
+        });
+
+        it('should not allow regular user to remove option', async () => {
+            const options = await polls.getPollOptions(testPollId);
+            const optionToRemove = options[0];
+
+            try {
+                await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+    });
+
+    describe('Poll Lifecycle Management', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Lifecycle Test Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to close poll early', async () => {
+            await polls.close(testPollId, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert(poll.endDate);
+            assert(poll.endDate <= Date.now());
+        });
+
+        it('should not allow regular user to close poll', async () => {
+            try {
+                await polls.close(testPollId, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should allow admin to reopen closed poll', async () => {
+            await polls.close(testPollId, adminUid);
+            
+            const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
+            await polls.reopen(testPollId, futureDate, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.strictEqual(poll.endDate, futureDate);
+        });
+
+        it('should not allow regular user to reopen poll', async () => {
+            await polls.close(testPollId, adminUid);
+
+            try {
+                await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+    });
+
+    describe('Poll Settings', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Settings Test Poll',
+                options: ['Option A', 'Option B'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow updating poll settings', async () => {
+            const settings = {
+                allowRevote: true,
+                hideResults: false,
+            };
+
+            await polls.updateSettings(testPollId, settings, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.deepStrictEqual(poll.settings, settings);
+        });
+
+        it('should allow setting poll end date', async () => {
+            const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
+            
+            await polls.setEndDate(testPollId, endDate, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.strictEqual(poll.endDate, endDate);
+        });
+    });
+
+    describe('Poll Duplication', () => {
+        let sourcePollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Source Poll',
+                options: ['Original Option 1', 'Original Option 2'],
+            };
+            sourcePollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to duplicate existing poll', async () => {
+            const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
+            
+            assert(duplicatedPollId);
+            assert.notStrictEqual(duplicatedPollId, sourcePollId);
+            
+            const [sourcePoll, duplicatedPoll] = await Promise.all([
+                polls.getPollData(sourcePollId),
+                polls.getPollData(duplicatedPollId),
+            ]);
+            
+            assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
+            assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
+        });
+
+        it('should create poll from template data', async () => {
+            const templateData = {
+                title: 'Template Poll',
+                options: ['Template Option 1', 'Template Option 2'],
+            };
+
+            const pollId = await polls.createFromTemplate(templateData, adminUid);
+            
+            assert(pollId);
+            
+            const poll = await polls.getPollData(pollId);
+            assert.strictEqual(poll.title, 'Template Poll');
+        });
+    });
+
+    describe('Poll Existence and Validation', () => {
+        it('should check if poll exists', async () => {
+            const pollData = {
+                title: 'Existence Test Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            
+            const exists = await polls.exists(pollId);
+            assert.strictEqual(exists, true);
+            
+            const nonExistentExists = await polls.exists('nonexistent');
+            assert.strictEqual(nonExistentExists, false);
+        });
+
+        it('should check multiple polls existence', async () => {
+            const pollData1 = {
+                title: 'Batch Test Poll 1',
+                options: ['Option 1', 'Option 2'],
+            };
+            const pollData2 = {
+                title: 'Batch Test Poll 2',
+                options: ['Option A', 'Option B'],
+            };
+
+            const [pollId1, pollId2] = await Promise.all([
+                polls.create(pollData1, adminUid),
+                polls.create(pollData2, adminUid),
+            ]);
+            
+            const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
+            
+            assert.strictEqual(existenceResults[0], true);
+            assert.strictEqual(existenceResults[1], true);
+            assert.strictEqual(existenceResults[2], false);
+        });
+
+        it('should validate poll data correctly', async () => {
+            const validPollData = {
+                title: 'Valid Poll',
+                options: ['Option 1', 'Option 2'],
+                settings: {
+                    allowRevote: true,
+                    hideResults: false,
+                },
+            };
+
+            await polls.validatePollData(validPollData);
+        });
+    });
+});

--- a/test/topics.js
+++ b/test/topics.js
@@ -2306,6 +2306,39 @@ describe('Topic\'s', () => {
 		});
 	});
 
+	describe('recent topics', () => {
+		let category;
+		before(async () => {
+			category = await categories.create({ name: 'recent' });
+			// create a couple topics
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'first recent topic',
+				content: 'topic 1 OP',
+			});
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'second recent topic',
+				content: 'topic 2 OP',
+			});
+		});
+
+		it('should get topics ordered by most recent first', async () => {
+			const data = await topics.getRecentTopics({
+				cids: [category.cid],
+				uid: topic.userId,
+				start: 0,
+				stop: -1,
+			});
+			assert(data);
+			assert(Array.isArray(data.topics));
+			assert.strictEqual(data.topics[0].title, 'second recent topic');
+			assert.strictEqual(data.topics[1].title, 'first recent topic');
+		});
+	});
+	
 	describe('scheduled topics', () => {
 		let categoryObj;
 		let topicData;

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/anonymousToggle.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/anonymousToggle.tpl
@@ -1,0 +1,7 @@
+<div class="form-check form-check-inline">
+	<input class="form-check-input" type="checkbox" id="anonymous-checkbox" name="anonymous" title="[[category:anonymous-checkbox-tooltip]]">
+	<label class="form-check-label text-sm" for="anonymous-checkbox">
+		<i class="fa fa-user-secret me-1"></i>
+		Anonymous
+	</label>
+</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/newTopic.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/newTopic.tpl
@@ -1,22 +1,27 @@
 <noscript><div class="dropdown" component="category-selector"></noscript>
-<button component="category/post" for="category-dropdown-check" class="btn btn-primary btn-sm text-nowrap" id="new_topic" role="button">
-	[[category:new-topic-button]]
-</button>
+
+<div class="d-flex align-items-center gap-2">
+    <!-- New Topic Button -->
+    <button component="category/post" for="category-dropdown-check" class="btn btn-primary btn-sm text-nowrap" id="new_topic" role="button">
+        [[category:new-topic-button]]
+    </button>
+</div>
+
 <noscript>
-	<input type="checkbox" class="hidden" id="category-dropdown-check" aria-hidden="true">
-	<ul component="category/list" class="dropdown-menu p-1 text-sm category-dropdown-menu ghost-scrollbar" role="menu">
-		{{{each categories}}}
-		<li role="presentation" class="category {{{if categories.disabledClass}}}disabled{{{end}}}">
-			<a role="menu-item" href="{config.relative_path}/compose?cid={categories.cid}">{categories.level}
-				<span component="category-markup">
-					<div class="category-item d-inline-block">
-						{buildCategoryIcon(@value, "24px", "rounded-circle")}
-						{categories.name}
-					</div>
-				</span>
-			</a>
-		</li>
-		{{{end}}}
-	</ul>
+    <input type="checkbox" class="hidden" id="category-dropdown-check" aria-hidden="true">
+    <ul component="category/list" class="dropdown-menu p-1 text-sm category-dropdown-menu ghost-scrollbar" role="menu">
+        {{{each categories}}}
+        <li role="presentation" class="category {{{if categories.disabledClass}}}disabled{{{end}}}">
+			<a role="menu-item" href="{config.relative_path}/compose?cid={categories.cid}" class="new-topic-link">{categories.level}
+                <span component="category-markup">
+                    <div class="category-item d-inline-block">
+                        {buildCategoryIcon(@value, "24px", "rounded-circle")}
+                        {categories.name}
+                    </div>
+                </span>
+            </a>
+        </li>
+        {{{end}}}
+    </ul>
 </div>
 </noscript>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -38,10 +38,12 @@
 			<div class="d-flex gap-1 align-items-center">
 				{{{ if (template.category || template.world) }}}
 					{{{ if privileges.topics:create }}}
+					<!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}
+					<!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 					<!-- IMPORT partials/buttons/newTopic.tpl -->
 					{{{ end }}}
 				{{{ end }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -1,29 +1,36 @@
 {{{ if privileges.topics:reply }}}
 <div component="topic/quickreply/container" class="quick-reply d-flex gap-3 mb-4">
-	<div class="icon hidden-xs">
-		<a class="d-inline-block position-relative" href="{{{ if loggedInUser.userslug }}}{config.relative_path}/user/{loggedInUser.userslug}{{{ else }}}#{{{ end }}}">
-			{buildAvatar(loggedInUser, "48px", true, "", "user/picture")}
-			{{{ if loggedInUser.status }}}<span component="user/status" class="position-absolute top-100 start-100 border border-white border-2 rounded-circle status {loggedInUser.status}"><span class="visually-hidden">[[global:{loggedInUser.status}]]</span></span>{{{ end }}}
-		</a>
-	</div>
-	<form class="flex-grow-1 d-flex flex-column gap-2" method="post" action="{config.relative_path}/compose">
-		<input type="hidden" name="tid" value="{tid}" />
-		<input type="hidden" name="_csrf" value="{config.csrf_token}" />
-		<div class="quickreply-message position-relative">
-			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
-			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
-		</div>
-		<div>
-			<div class="d-flex justify-content-end gap-2">
-				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>
-				<button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
-				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
-			</div>
-		</div>
-	</form>
-	<form class="d-none" component="topic/quickreply/upload" method="post" enctype="multipart/form-data">
-		<input type="file" name="files[]" multiple class="hidden"/>
-	</form>
+    <div class="icon hidden-xs">
+        <a class="d-inline-block position-relative" href="{{{ if loggedInUser.userslug }}}{config.relative_path}/user/{loggedInUser.userslug}{{{ else }}}#{{{ end }}}">
+            {buildAvatar(loggedInUser, "48px", true, "", "user/picture")}
+            {{{ if loggedInUser.status }}}<span component="user/status" class="position-absolute top-100 start-100 border border-white border-2 rounded-circle status {loggedInUser.status}"><span class="visually-hidden">[[global:{loggedInUser.status}]]</span></span>{{{ end }}}
+        </a>
+    </div>
+    <form class="flex-grow-1 d-flex flex-column gap-2" method="post" action="{config.relative_path}/compose">
+        <input type="hidden" name="tid" value="{tid}" />
+        <input type="hidden" name="_csrf" value="{config.csrf_token}" />
+        <div class="quickreply-message position-relative">
+            <textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
+            <div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
+        </div>
+        <div>
+            <div class="d-flex justify-content-end gap-2 align-items-center">
+                <!-- Anonymous checkbox -->
+                <!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 
+                <!-- Upload / Expand / Submit buttons -->
+                <button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border">
+                    <i class="fa fa-upload"></i>
+                </button>
+                <button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]">
+                    <i class="fa fa-expand"></i>
+                </button>
+                <button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
+            </div>
+        </div>
+    </form>
+    <form class="d-none" component="topic/quickreply/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="files[]" multiple class="hidden"/>
+    </form>
 </div>
 {{{ end }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,6 +23,11 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
+					{{{ if ./pinned && ./contentPreview }}}
+					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
+						{./contentPreview}
+					</div>
+					{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,11 +23,15 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
-					{{{ if ./pinned && ./contentPreview }}}
-					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
-						{./contentPreview}
-					</div>
-					{{{ end }}}
+				{{{ if ./pinned }}}
+				<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break w-100">
+    				{{{ if ./contentPreview }}}
+            	{{ ./contentPreview }}
+        		{{{ else }}}
+            	No preview available
+        		{{{ end }}}
+				</div>
+				{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>


### PR DESCRIPTION
Added a new UI feature that displays a content preview for pinned topics when viewing a category board. The preview shows the sanitized text from the first post of each pinned topic, allowing users to get a glimpse of the content without opening the topic.

- Modified: vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl

- Utilizes existing pinned property to identify pinned topics

- Uses new _contentPreview_ data field provided by backend services
