### PR TITLE
(MKWEE P1B modification) Refactor (public/src/client/topic/posts.js:71): Split complex binary expression into more-readable if statements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Ashley Liu
+Nicole Huang
+Matthew Kwee
+Mandy Yin
+
+
 # ![NodeBB](public/images/sm-card.png)
 
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Ashley Liu
+
 Nicole Huang
+
 Matthew Kwee
+
 Mandy Yin
 
 

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -113,6 +113,8 @@
 	"thread-tools.markAsUnreadForAll": "Mark Unread For All",
 	"thread-tools.pin": "Pin Topic",
 	"thread-tools.unpin": "Unpin Topic",
+	"thread-tools.private": "Private Topic",
+	"thread-tools.unprivate": "Public Topic",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
 	"thread-tools.move": "Move Topic",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -100,6 +100,8 @@
     "thread-tools.markAsUnreadForAll": "Mark Unread For All",
     "thread-tools.pin": "Pin Topic",
     "thread-tools.unpin": "Unpin Topic",
+    "thread-tools.private": "Private Topic",
+    "thread-tools.unprivate": "Public Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
     "thread-tools.move": "Move Topic",

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -234,6 +234,9 @@ TopicObjectSlim:
           type: number
           description: Whether or not this particular topic is pinned to the top of the
             category
+        private:
+          type: number
+          description: Whether this topic is private or public
         timestamp:
           type: number
         timestampISO:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -148,6 +148,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/private:
+    $ref: 'write/topics/tid/private.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/private.yaml
+++ b/public/openapi/write/topics/tid/private.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - topics
+  summary: make a topic private
+  description: This operation makes a topic private.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made private.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: make a topic public (unprivate)
+  description: This operation makes a private topic public.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made public
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -134,6 +134,8 @@ define('forum/category/tools', [
 		socket.on('event:topic_purged', onTopicPurged);
 		socket.on('event:topic_locked', setLockedState);
 		socket.on('event:topic_unlocked', setLockedState);
+		socket.on('event:topic_private', setPrivateState);
+		socket.on('event:topic_unprivate', setPrivateState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
@@ -182,6 +184,8 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_unlocked', setLockedState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
+		socket.removeListener('event:topic_private', setPrivateState);
+		socket.removeListener('event:topic_unprivate', setPrivateState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
 	};
 
@@ -253,6 +257,10 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('locked');
 	}
 
+	// function isTopicPrivate(tid) {
+	// return getTopicEl(tid).hasClass('private');
+	// }
+
 	function isTopicPinned(tid) {
 		return getTopicEl(tid).hasClass('pinned');
 	}
@@ -269,6 +277,13 @@ define('forum/category/tools', [
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('deleted', data.isDeleted);
 		topic.find('[component="topic/locked"]').toggleClass('hidden', !data.isDeleted);
+	}
+
+	function setPrivateState(data) {
+		const topic = getTopicEl(data.tid);
+		topic.toggleClass('private', data.isPrivate);
+		topic.find('[component="topic/private"]').toggleClass('hidden', !data.isPrivate);
+		ajaxify.refresh();
 	}
 
 	function setPinnedState(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -26,6 +26,9 @@ define('forum/topic/events', [
 		'event:topic_locked': threadTools.setLockedState,
 		'event:topic_unlocked': threadTools.setLockedState,
 
+		'event:topic_private': threadTools.setPrivateState,
+		'event:topic_unprivate': threadTools.setPrivateState,
+
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -67,20 +67,10 @@ define('forum/topic/posts', [
 			post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
-			
-			// Minor refactor; just broke up long binary statement into
-			// multiple shorter ones.
-			post.display_post_menu = false;
-
-			if (ajaxify.data.privileges.isAdminOrMod) {
-				post.display_post_menu = true;
-			} else if (post.selfPost && !ajaxify.data.locked && !post.deleted) {
-				post.display_post_menu = true;
-			} else if (post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) {
-				post.display_post_menu = true;
-			} else if ((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted) {
-				post.display_post_menu = true;
-			}
+			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
+				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
+				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
+				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
 		});
 	};
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -67,10 +67,20 @@ define('forum/topic/posts', [
 			post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
-			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
-				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
-				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
-				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
+			
+			// Minor refactor; just broke up long binary statement into
+			// multiple shorter ones.
+			post.display_post_menu = false;
+
+			if (ajaxify.data.privileges.isAdminOrMod) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && !ajaxify.data.locked && !post.deleted) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) {
+				post.display_post_menu = true;
+			} else if ((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted) {
+				post.display_post_menu = true;
+			}
 		});
 	};
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,11 +51,21 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/private"]', function () {
+			topicCommand('put', '/private', 'private');
+			return false;
+		});
+
+		topicContainer.on('click', '[component="topic/unprivate"]', function () {
+			topicCommand('del', '/private', 'unprivate');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
 		});
-
+  
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
 			return false;
@@ -361,6 +371,21 @@ define('forum/topic/threadTools', [
 
 		threadEl.toggleClass('deleted', data.isDelete);
 		ajaxify.data.deleted = data.isDelete ? 1 : 0;
+
+		posts.addTopicEvents(data.events);
+	};
+
+	ThreadTools.setPrivateState = function (data) {
+		const threadEl = components.get('topic');
+		if (String(data.tid) !== threadEl.attr('data-tid')) {
+			return;
+		}
+		
+		components.get('topic/private').toggleClass('hidden', data.isPrivate).parent().attr('hidden', data.isPrivate ? '' : null);
+		components.get('topic/unprivate').toggleClass('hidden', !data.isPrivate).parent().attr('hidden', !data.isPrivate ? '' : null);
+		const icon = $('[component="topic/labels"] [component="topic/private"]');
+		icon.toggleClass('hidden', !data.isPrivate);
+		ajaxify.data.private = data.isPrivate;
 
 		posts.addTopicEvents(data.events);
 	};

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -146,9 +146,19 @@ topicsAPI.purge = async function (caller, data) {
 	});
 };
 
+topicsAPI.private = async function (caller, { tids }) {
+	await doTopicAction('private', 'event:topic_private', caller, { tids });
+};
+
+topicsAPI.unprivate = async function (caller, { tids }) {
+	await doTopicAction('unprivate', 'event:topic_unprivate', caller, { tids });
+};
+
+
+// here could be when we pin a post
 topicsAPI.pin = async function (caller, { tids, expiry }) {
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
-
+	console.log('here');
 	if (expiry) {
 		await Promise.all(tids.map(async tid => topics.tools.setPinExpiry(tid, expiry, caller.uid)));
 	}

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -79,6 +79,16 @@ Topics.unpin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.private = async (req, res) => {
+	await api.topics.private(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.unprivate = async (req, res) => {
+	await api.topics.unprivate(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.lock = async (req, res) => {
 	await api.topics.lock(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -174,6 +174,10 @@ privsTopics.canEdit = async function (tid, uid) {
 	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
 };
 
+privsTopics.canPrivate = async function (tid, uid) {
+	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
+};
+
 privsTopics.isOwnerOrAdminOrMod = async function (tid, uid) {
 	const [isOwner, isAdminOrMod] = await Promise.all([
 		topics.isOwner(tid, uid),

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,6 +24,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
 	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
 
+	setupApiRoute(router, 'put', '/:tid/private', [...middlewares, middleware.assert.topic], controllers.write.topics.private);
+	setupApiRoute(router, 'delete', '/:tid/private', [...middlewares], controllers.write.topics.unprivate);
+
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -13,7 +13,7 @@ const intFields = [
 	'viewcount', 'postercount', 'followercount',
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
-	'lastposttime', 'deleterUid',
+	'lastposttime', 'deleterUid', 'private',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -49,6 +49,14 @@ Events._types = {
 		icon: 'fa-trash',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-deleted-topic'),
 	},
+	private: {
+		icon: 'fa-eye-slash',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-private'),
+	},
+	unprivate: {
+		icon: 'fa-eye',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-public'),
+	},
 	restore: {
 		icon: 'fa-trash-o',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-restored-topic'),

--- a/src/views/partials/topic/topic-menu-list.tpl
+++ b/src/views/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,14 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if private }}}hidden{{{ end }}}>
+	<a component="topic/private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.private]]</a>
+</li>
+
+<li {{{ if !private }}}hidden{{{ end }}}>
+	<a component="topic/unprivate" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.unprivate]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue

**Please provide a link to the associated GitHub issue:**

**Link to the associated GitHub issue:** [ISSUE](https://github.com/CMU-313/NodeBB/issues/190)

**Full path to the refactored file:** [FILE](https://github.com/crypt0chicken/NodeBB/blob/main/public/src/client/topic/posts.js)

**What do you think this file does?**
*(Your answer does not have to be 100% correct; give a reasonable, evidence‑based guess.)*
I believe this file controls the creation, display, and editing of posts, due to the "Posts.onNewPost()" function running upon creation of a post, the "function createNewPosts()" function (presumably) loading new posts as the user scrolls, and "Posts.modifyPostsByPrivileges()" - the function I modified - controlling what tools a user gets access to.

**What is the scope of your refactoring within that file?**
I modified the "Posts.modifyPostsByPrivileges()" function, specifically Lines 71-72 (now Lines 74-84).

**Which Qlty‑reported issue did you address?**
Complex Binary Expressions in Posts.modifyPostsByPrivileges(), Lines 71-72

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**
The issue impacted readability, and resolving it makes it easier to understand the conditions under which the post menu is displayed to an admin or user.

**What changes did you make to resolve the issue?**
I converted the long binary expression into a series of if/else statements. The logical flow of the function was left unchanged.

**How do your changes improve adaptability? Did you consider alternatives?**
The if/else statements split up the binary expression into more-readable logic. While I could have used multiple A=(A || B); type statements, I believe if/else accomplishes the goal in a neater, more understandable format.

## 3. Validation

**How did you trigger the refactored code path from the UI?**
By creating a new post or reply, I can trigger "Posts.modifyPostsByPrivileges()" to run, which contains my refactored code.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*
Screenshot of trigger before refactoring (Apologies for the messy bookmark toolbar - I'll get around to cleaning it up sometime soon):
<img width="1280" height="764" alt="Triggered_OLD" src="https://github.com/user-attachments/assets/b4931b81-ed1a-40de-8af5-bf29e80c00ec" />

Screenshot of trigger after refactoring (Temporary console.log lines have since been removed):
<img width="1280" height="764" alt="Triggered_REFACTORED" src="https://github.com/user-attachments/assets/58efa569-a843-465b-b8e8-7333e5debd99" />

**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
Screenshot:
<img width="1280" height="764" alt="fewer_smells" src="https://github.com/user-attachments/assets/20ea3ea8-de13-443d-a1f2-67e66c6c1638" />

Qlty output before refactoring:
```
$ qlty smells --no-snippets public/src/client/topic/posts.js
[Initial qlty output omitted]
public/src/client/topic/posts.js
 156  Function with many parameters (count = 5): createNewPosts
  71  Complex binary expression
  72  Complex binary expression
   1  High total complexity (count = 105)
 156  Function with high complexity (count = 29): createNewPosts
 162  Function with high complexity (count = 10): removeAlreadyAddedPosts
 249  Function with high complexity (count = 11): loadMorePosts
 324  Function with high complexity (count = 13): addNecroPostMessage
```

Qlty output after refactoring:
```
$ qlty smells --no-snippets public/src/client/topic/posts.js
[Initial qlty output omitted]
public/src/client/topic/posts.js
 169  Function with many parameters (count = 5): createNewPosts
   1  High total complexity (count = 107)
  61  Function with high complexity (count = 11): modifyPostsByPrivileges
 169  Function with high complexity (count = 29): createNewPosts
 175  Function with high complexity (count = 10): removeAlreadyAddedPosts
 262  Function with high complexity (count = 11): loadMorePosts
 337  Function with high complexity (count = 13): addNecroPostMessage
```
