### PR TITLE
feat(private-frontend):  show "Private" badge on all topic headers, visible on all pages + user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Ashley Liu
+Nicole Huang
+Matthew Kwee
+Mandy Yin
+
+
 # ![NodeBB](public/images/sm-card.png)
 
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Ashley Liu
+
 Nicole Huang
+
 Matthew Kwee
+
 Mandy Yin
 
 

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -113,6 +113,8 @@
 	"thread-tools.markAsUnreadForAll": "Mark Unread For All",
 	"thread-tools.pin": "Pin Topic",
 	"thread-tools.unpin": "Unpin Topic",
+	"thread-tools.private": "Private Topic",
+	"thread-tools.unprivate": "Public Topic",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
 	"thread-tools.move": "Move Topic",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -100,6 +100,8 @@
     "thread-tools.markAsUnreadForAll": "Mark Unread For All",
     "thread-tools.pin": "Pin Topic",
     "thread-tools.unpin": "Unpin Topic",
+    "thread-tools.private": "Private Topic",
+    "thread-tools.unprivate": "Public Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
     "thread-tools.move": "Move Topic",

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -234,6 +234,9 @@ TopicObjectSlim:
           type: number
           description: Whether or not this particular topic is pinned to the top of the
             category
+        private:
+          type: number
+          description: Whether this topic is private or public
         timestamp:
           type: number
         timestampISO:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -148,6 +148,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/private:
+    $ref: 'write/topics/tid/private.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/private.yaml
+++ b/public/openapi/write/topics/tid/private.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - topics
+  summary: make a topic private
+  description: This operation makes a topic private.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made private.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: make a topic public (unprivate)
+  description: This operation makes a private topic public.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made public
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -159,7 +159,7 @@ define('forum/category', [
 		console.log('addPrivateBadgesToTopics called');
 
 		// Add private badge to ALL topics for demo purposes
-		$('[component="category/topic"]').each(function() {
+		$('[component="category/topic"]').each(function () {
 			const topicEl = $(this);
 			const labelsContainer = topicEl.find('[component="topic/labels"]');
 
@@ -174,7 +174,7 @@ define('forum/category', [
 		});
 
 		// Also try adding to any visible watching badges
-		$('[component="topic/watched"]:visible').each(function() {
+		$('[component="topic/watched"]:visible').each(function () {
 			const watchedEl = $(this);
 			if (!watchedEl.siblings('.private-badge').length) {
 				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -53,6 +53,9 @@ define('forum/category', [
 
 		new clipboard('[data-clipboard-text]');
 
+		// Add private badges to all topics with watching tags
+		addPrivateBadgesToTopics();
+
 		hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
 		hooks.fire('action:category.loaded', { cid: ajaxify.data.cid });
 	};
@@ -149,6 +152,35 @@ define('forum/category', [
 		}, function (data, done) {
 			hooks.fire('action:topics.loaded', { topics: data.topics });
 			callback(data, done);
+		});
+	}
+
+	function addPrivateBadgesToTopics() {
+		console.log('addPrivateBadgesToTopics called');
+
+		// Add private badge to ALL topics for demo purposes
+		$('[component="category/topic"]').each(function() {
+			const topicEl = $(this);
+			const labelsContainer = topicEl.find('[component="topic/labels"]');
+
+			console.log('Processing topic, labels container found:', labelsContainer.length);
+
+			// Only add if badge doesn't already exist
+			if (labelsContainer.length && !labelsContainer.find('.private-badge').length) {
+				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');
+				labelsContainer.append(privateBadge);
+				console.log('Private badge added to topic');
+			}
+		});
+
+		// Also try adding to any visible watching badges
+		$('[component="topic/watched"]:visible').each(function() {
+			const watchedEl = $(this);
+			if (!watchedEl.siblings('.private-badge').length) {
+				const privateBadge = $('<span class="badge border border-gray-300 text-body private-badge ms-1"><i class="fa fa-lock"></i> Private</span>');
+				watchedEl.after(privateBadge);
+				console.log('Private badge added after watching badge');
+			}
 		});
 	}
 

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -134,6 +134,8 @@ define('forum/category/tools', [
 		socket.on('event:topic_purged', onTopicPurged);
 		socket.on('event:topic_locked', setLockedState);
 		socket.on('event:topic_unlocked', setLockedState);
+		socket.on('event:topic_private', setPrivateState);
+		socket.on('event:topic_unprivate', setPrivateState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
@@ -182,6 +184,8 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_unlocked', setLockedState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
+		socket.removeListener('event:topic_private', setPrivateState);
+		socket.removeListener('event:topic_unprivate', setPrivateState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
 	};
 
@@ -253,6 +257,10 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('locked');
 	}
 
+	// function isTopicPrivate(tid) {
+	// return getTopicEl(tid).hasClass('private');
+	// }
+
 	function isTopicPinned(tid) {
 		return getTopicEl(tid).hasClass('pinned');
 	}
@@ -269,6 +277,13 @@ define('forum/category/tools', [
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('deleted', data.isDeleted);
 		topic.find('[component="topic/locked"]').toggleClass('hidden', !data.isDeleted);
+	}
+
+	function setPrivateState(data) {
+		const topic = getTopicEl(data.tid);
+		topic.toggleClass('private', data.isPrivate);
+		topic.find('[component="topic/private"]').toggleClass('hidden', !data.isPrivate);
+		ajaxify.refresh();
 	}
 
 	function setPinnedState(data) {

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -77,6 +77,26 @@ define('forum/topic', [
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
 
+	//attempt to put pivate toggle here
+
+	//<div class="composer-footer">
+	//   <button class="composer-hide">Hide</button>
+	//   <button class="composer-discard">Discard</button>
+
+	//   <label class="composer-private">
+	//     <input type="checkbox" id="private-toggle">
+	//     Private
+	//   </label>
+
+	//   <button class="composer-submit">Submit</button>
+	// </div>
+
+	// 	{{{ if topic.isPrivate }}}
+	// <span class="badge badge-warning">Private</span>
+	// {{{ end }}}
+
+
+
 	function handleTopicSearch() {
 		require(['mousetrap'], (mousetrap) => {
 			if (config.topicSearchEnabled) {
@@ -261,6 +281,35 @@ define('forum/topic', [
 		hooks.registerPage('action:posts.loaded', addCopyCodeButton);
 		hooks.registerPage('action:topic.loaded', addCopyCodeButton);
 		hooks.registerPage('action:posts.edited', addCopyCodeButton);
+
+		function addPrivateBadgeToTopicInfo() {
+			// Add private badge next to category and watching tags
+			console.log('addPrivateBadgeToTopicInfo called');
+
+			// Try multiple selectors to find the right place
+			let targetEl = $('.topic-info');
+			if (!targetEl.length) {
+				targetEl = $('[component="topic/title"]').parent();
+			}
+			if (!targetEl.length) {
+				targetEl = $('.topic-title').parent().parent();
+			}
+
+			console.log('Found target element:', targetEl.length);
+
+			// Only add if badge doesn't already exist
+			if (targetEl.length && !targetEl.find('.private-badge').length) {
+				const privateBadge = $('<span class="badge badge-warning private-badge ms-2">Private</span>');
+				targetEl.append(privateBadge);
+				console.log('Private badge added');
+			} else {
+				console.log('Badge already exists or no target element found');
+			}
+		}
+
+		hooks.registerPage('action:posts.loaded', addPrivateBadgeToTopicInfo);
+		hooks.registerPage('action:topic.loaded', addPrivateBadgeToTopicInfo);
+		hooks.registerPage('action:posts.edited', addPrivateBadgeToTopicInfo);
 	}
 
 	function addParentHandler() {

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -91,7 +91,7 @@ define('forum/topic', [
 	//   <button class="composer-submit">Submit</button>
 	// </div>
 
-	// 	{{{ if topic.isPrivate }}}
+	// {{{ if topic.isPrivate }}}
 	// <span class="badge badge-warning">Private</span>
 	// {{{ end }}}
 

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -26,6 +26,9 @@ define('forum/topic/events', [
 		'event:topic_locked': threadTools.setLockedState,
 		'event:topic_unlocked': threadTools.setLockedState,
 
+		'event:topic_private': threadTools.setPrivateState,
+		'event:topic_unprivate': threadTools.setPrivateState,
+
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -67,20 +67,10 @@ define('forum/topic/posts', [
 			post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
-			
-			// Minor refactor; just broke up long binary statement into
-			// multiple shorter ones.
-			post.display_post_menu = false;
-
-			if (ajaxify.data.privileges.isAdminOrMod) {
-				post.display_post_menu = true;
-			} else if (post.selfPost && !ajaxify.data.locked && !post.deleted) {
-				post.display_post_menu = true;
-			} else if (post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) {
-				post.display_post_menu = true;
-			} else if ((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted) {
-				post.display_post_menu = true;
-			}
+			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
+				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
+				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
+				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
 		});
 	};
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -67,10 +67,20 @@ define('forum/topic/posts', [
 			post.display_delete_tools = (ajaxify.data.privileges['posts:delete'] && post.selfPost) || ajaxify.data.privileges.isAdminOrMod;
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
-			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
-				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
-				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
-				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
+			
+			// Minor refactor; just broke up long binary statement into
+			// multiple shorter ones.
+			post.display_post_menu = false;
+
+			if (ajaxify.data.privileges.isAdminOrMod) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && !ajaxify.data.locked && !post.deleted) {
+				post.display_post_menu = true;
+			} else if (post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) {
+				post.display_post_menu = true;
+			} else if ((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted) {
+				post.display_post_menu = true;
+			}
 		});
 	};
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,11 +51,21 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/private"]', function () {
+			topicCommand('put', '/private', 'private');
+			return false;
+		});
+
+		topicContainer.on('click', '[component="topic/unprivate"]', function () {
+			topicCommand('del', '/private', 'unprivate');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
 		});
-
+  
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
 			return false;
@@ -361,6 +371,21 @@ define('forum/topic/threadTools', [
 
 		threadEl.toggleClass('deleted', data.isDelete);
 		ajaxify.data.deleted = data.isDelete ? 1 : 0;
+
+		posts.addTopicEvents(data.events);
+	};
+
+	ThreadTools.setPrivateState = function (data) {
+		const threadEl = components.get('topic');
+		if (String(data.tid) !== threadEl.attr('data-tid')) {
+			return;
+		}
+		
+		components.get('topic/private').toggleClass('hidden', data.isPrivate).parent().attr('hidden', data.isPrivate ? '' : null);
+		components.get('topic/unprivate').toggleClass('hidden', !data.isPrivate).parent().attr('hidden', !data.isPrivate ? '' : null);
+		const icon = $('[component="topic/labels"] [component="topic/private"]');
+		icon.toggleClass('hidden', !data.isPrivate);
+		ajaxify.data.private = data.isPrivate;
 
 		posts.addTopicEvents(data.events);
 	};

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -146,9 +146,19 @@ topicsAPI.purge = async function (caller, data) {
 	});
 };
 
+topicsAPI.private = async function (caller, { tids }) {
+	await doTopicAction('private', 'event:topic_private', caller, { tids });
+};
+
+topicsAPI.unprivate = async function (caller, { tids }) {
+	await doTopicAction('unprivate', 'event:topic_unprivate', caller, { tids });
+};
+
+
+// here could be when we pin a post
 topicsAPI.pin = async function (caller, { tids, expiry }) {
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
-
+	console.log('here');
 	if (expiry) {
 		await Promise.all(tids.map(async tid => topics.tools.setPinExpiry(tid, expiry, caller.uid)));
 	}

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -94,4 +94,43 @@ exports.post = async function (req, res) {
 	} catch (err) {
 		helpers.noScriptErrors(req, res, err.message, 400);
 	}
+
+	//Private toggle attempt
+
+	// postContainer.find('#private-toggle').on('change', function () {
+	// 	composer.posts[post_uuid].isPrivate = this.checked;
+	//   });
+
+	// if (action === 'topics.post') {
+	// 	composerData = {
+	// 	  ...composerData,
+	// 	  handle: handleEl ? handleEl.val() : undefined,
+	// 	  title: titleEl.val(),
+	// 	  content: bodyEl.val(),
+	// 	  thumb: thumbEl.val() || '',
+	// 	  cid: categoryList.getSelectedCid(),
+	// 	  tags: tags.getTags(post_uuid),
+	// 	  timestamp: scheduler.getTimestamp(),
+	  
+	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// 	};
+	//   }
+
+	// if (action === 'topics.post') {
+	// 	composerData = {
+	// 	  ...composerData,
+	// 	  handle: handleEl ? handleEl.val() : undefined,
+	// 	  title: titleEl.val(),
+	// 	  content: bodyEl.val(),
+	// 	  thumb: thumbEl.val() || '',
+	// 	  cid: categoryList.getSelectedCid(),
+	// 	  tags: tags.getTags(post_uuid),
+	// 	  timestamp: scheduler.getTimestamp(),
+
+	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// 	};
+	//   }
+	  
+	  
+	  
 };

--- a/src/controllers/composer.js
+++ b/src/controllers/composer.js
@@ -98,37 +98,37 @@ exports.post = async function (req, res) {
 	//Private toggle attempt
 
 	// postContainer.find('#private-toggle').on('change', function () {
-	// 	composer.posts[post_uuid].isPrivate = this.checked;
+	// composer.posts[post_uuid].isPrivate = this.checked;
 	//   });
 
 	// if (action === 'topics.post') {
-	// 	composerData = {
-	// 	  ...composerData,
-	// 	  handle: handleEl ? handleEl.val() : undefined,
-	// 	  title: titleEl.val(),
-	// 	  content: bodyEl.val(),
-	// 	  thumb: thumbEl.val() || '',
-	// 	  cid: categoryList.getSelectedCid(),
-	// 	  tags: tags.getTags(post_uuid),
-	// 	  timestamp: scheduler.getTimestamp(),
-	  
-	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// 	};
+	// composerData = {
+	//   ...composerData,
+	//   handle: handleEl ? handleEl.val() : undefined,
+	//   title: titleEl.val(),
+	//   content: bodyEl.val(),
+	//   thumb: thumbEl.val() || '',
+	//   cid: categoryList.getSelectedCid(),
+	//   tags: tags.getTags(post_uuid),
+	//   timestamp: scheduler.getTimestamp(),
+
+	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// };
 	//   }
 
 	// if (action === 'topics.post') {
-	// 	composerData = {
-	// 	  ...composerData,
-	// 	  handle: handleEl ? handleEl.val() : undefined,
-	// 	  title: titleEl.val(),
-	// 	  content: bodyEl.val(),
-	// 	  thumb: thumbEl.val() || '',
-	// 	  cid: categoryList.getSelectedCid(),
-	// 	  tags: tags.getTags(post_uuid),
-	// 	  timestamp: scheduler.getTimestamp(),
+	// composerData = {
+	//   ...composerData,
+	//   handle: handleEl ? handleEl.val() : undefined,
+	//   title: titleEl.val(),
+	//   content: bodyEl.val(),
+	//   thumb: thumbEl.val() || '',
+	//   cid: categoryList.getSelectedCid(),
+	//   tags: tags.getTags(post_uuid),
+	//   timestamp: scheduler.getTimestamp(),
 
-	// 	  isPrivate: composer.posts[post_uuid].isPrivate || false,
-	// 	};
+	//   isPrivate: composer.posts[post_uuid].isPrivate || false,
+	// };
 	//   }
 	  
 	  

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -79,6 +79,16 @@ Topics.unpin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.private = async (req, res) => {
+	await api.topics.private(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.unprivate = async (req, res) => {
+	await api.topics.unprivate(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.lock = async (req, res) => {
 	await api.topics.lock(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/posts/category.js
+++ b/src/posts/category.js
@@ -43,4 +43,12 @@ module.exports = function (Posts) {
 		const isMembers = await db.isSortedSetMembers(`cid:${parseInt(cid, 10)}:pids`, pids);
 		return pids.filter((pid, index) => pid && isMembers[index]);
 	}
+
+	//<li class="topic-title">
+	//   <a href="{relative_path}/topic/{topics.slug}">{topics.title}</a>
+	//   {{{ if topics.isPrivate }}}
+	//     <span class="badge badge-warning">Private</span>
+	//   {{{ end }}}
+	// </li>
+
 };

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -174,6 +174,10 @@ privsTopics.canEdit = async function (tid, uid) {
 	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
 };
 
+privsTopics.canPrivate = async function (tid, uid) {
+	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
+};
+
 privsTopics.isOwnerOrAdminOrMod = async function (tid, uid) {
 	const [isOwner, isAdminOrMod] = await Promise.all([
 		topics.isOwner(tid, uid),

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,6 +24,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
 	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
 
+	setupApiRoute(router, 'put', '/:tid/private', [...middlewares, middleware.assert.topic], controllers.write.topics.private);
+	setupApiRoute(router, 'delete', '/:tid/private', [...middlewares], controllers.write.topics.unprivate);
+
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -13,7 +13,7 @@ const intFields = [
 	'viewcount', 'postercount', 'followercount',
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
-	'lastposttime', 'deleterUid',
+	'lastposttime', 'deleterUid', 'private',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -49,6 +49,14 @@ Events._types = {
 		icon: 'fa-trash',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-deleted-topic'),
 	},
+	private: {
+		icon: 'fa-eye-slash',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-private'),
+	},
+	unprivate: {
+		icon: 'fa-eye',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-public'),
+	},
 	restore: {
 		icon: 'fa-trash-o',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-restored-topic'),

--- a/src/views/partials/topic/topic-menu-list.tpl
+++ b/src/views/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,14 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if private }}}hidden{{{ end }}}>
+	<a component="topic/private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.private]]</a>
+</li>
+
+<li {{{ if !private }}}hidden{{{ end }}}>
+	<a component="topic/unprivate" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.unprivate]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -28,6 +28,10 @@
 						<i class="fa fa-bell-o"></i>
 						<span>[[topic:watching]]</span>
 					</span>
+					<span class="badge border border-gray-300 text-body">
+						<i class="fa fa-lock"></i>
+						<span>Private</span>
+					</span>
 					<span component="topic/ignored" class="badge border border-gray-300 text-body {{{ if !./ignored }}}hidden{{{ end }}}">
 						<i class="fa fa-eye-slash"></i>
 						<span>[[topic:ignoring]]</span>


### PR DESCRIPTION
Summary

This PR enhances the private topics feature by ensuring that users see a "Private" tag on their posts across multiple views. The tag provides clear visual feedback that a topic was created as private.

Changes

public/src/client/topic.js

Updated hook registrations to call addPrivateBadgeToTopicInfo.

Function now finds .topic-info container and appends a Private badge in the topic header.

public/src/client/category.js

Added addPrivateBadgesToTopics to append Private badges on all topics in category, recent, and popular views (demo mode → currently shows badge on all topics).

vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl

Injected a <span> element with "Private" badge directly into the topic list template, ensuring badges always render on every topic header.

Testing

Rebuilt NodeBB via ./nodebb build.

Verified on:

Announcements category page → Private badge appears next to Watching/Category labels.

Recent page → Private badge visible on each topic.

Popular page → Private badge visible on each topic.

User account page → Private badge visible on all private topics.

Screenshots

<img width="1439" height="812" alt="Screenshot 2025-09-26 at 11 38 04 AM" src="https://github.com/user-attachments/assets/4648b477-5bcb-4457-9270-88e7e5d69591" />
<img width="1440" height="859" alt="Screenshot 2025-09-26 at 11 33 59 AM" src="https://github.com/user-attachments/assets/d7973d18-a80c-4f95-8040-56f4266f60cb" />


Notes

Currently configured to show the Private tag on all topics (for demo purposes).

In the future, front end logic will be integrated with backend and checks if a topic is actually private before rendering the badge.

All commits are linted, build runs successfully, and functionality verified locally.