### PR TITLE
Issue #12 (Hide Private Topics): Modify [src/api/topics.js: Topics.getTopicsByTids] to filter private topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Ashley Liu
+Nicole Huang
+Matthew Kwee
+Mandy Yin
+
+
 # ![NodeBB](public/images/sm-card.png)
 
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Ashley Liu
+
 Nicole Huang
+
 Matthew Kwee
+
 Mandy Yin
 
 

--- a/app.js
+++ b/app.js
@@ -17,7 +17,6 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 'use strict';
 
 require('./require-main');

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+
 'use strict';
 
 require('./require-main');

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -113,6 +113,8 @@
 	"thread-tools.markAsUnreadForAll": "Mark Unread For All",
 	"thread-tools.pin": "Pin Topic",
 	"thread-tools.unpin": "Unpin Topic",
+	"thread-tools.private": "Private Topic",
+	"thread-tools.unprivate": "Public Topic",
 	"thread-tools.lock": "Lock Topic",
 	"thread-tools.unlock": "Unlock Topic",
 	"thread-tools.move": "Move Topic",

--- a/public/language/en-US/topic.json
+++ b/public/language/en-US/topic.json
@@ -100,6 +100,8 @@
     "thread-tools.markAsUnreadForAll": "Mark Unread For All",
     "thread-tools.pin": "Pin Topic",
     "thread-tools.unpin": "Unpin Topic",
+    "thread-tools.private": "Private Topic",
+    "thread-tools.unprivate": "Public Topic",
     "thread-tools.lock": "Lock Topic",
     "thread-tools.unlock": "Unlock Topic",
     "thread-tools.move": "Move Topic",

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -234,6 +234,9 @@ TopicObjectSlim:
           type: number
           description: Whether or not this particular topic is pinned to the top of the
             category
+        private:
+          type: number
+          description: Whether this topic is private or public
         timestamp:
           type: number
         timestampISO:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -148,6 +148,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/private:
+    $ref: 'write/topics/tid/private.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/private.yaml
+++ b/public/openapi/write/topics/tid/private.yaml
@@ -1,0 +1,52 @@
+put:
+  tags:
+    - topics
+  summary: make a topic private
+  description: This operation makes a topic private.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made private.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+delete:
+  tags:
+    - topics
+  summary: make a topic public (unprivate)
+  description: This operation makes a private topic public.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully made public
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -128,6 +128,7 @@ define('forum/category/tools', [
 			});
 		});
 
+		// MKWEE BOOKMARK
 		CategoryTools.removeListeners();
 		socket.on('event:topic_deleted', setDeleteState);
 		socket.on('event:topic_restored', setDeleteState);
@@ -272,6 +273,7 @@ define('forum/category/tools', [
 	}
 
 	function setPinnedState(data) {
+		console.log('public/src/client/category/tools.js:setPinnedState\n');
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('pinned', data.isPinned);
 		topic.find('[component="topic/pinned"]').toggleClass('hidden', !data.isPinned);

--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -134,6 +134,8 @@ define('forum/category/tools', [
 		socket.on('event:topic_purged', onTopicPurged);
 		socket.on('event:topic_locked', setLockedState);
 		socket.on('event:topic_unlocked', setLockedState);
+		socket.on('event:topic_private', setPrivateState);
+		socket.on('event:topic_unprivate', setPrivateState);
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
@@ -182,6 +184,8 @@ define('forum/category/tools', [
 		socket.removeListener('event:topic_unlocked', setLockedState);
 		socket.removeListener('event:topic_pinned', setPinnedState);
 		socket.removeListener('event:topic_unpinned', setPinnedState);
+		socket.removeListener('event:topic_private', setPrivateState);
+		socket.removeListener('event:topic_unprivate', setPrivateState);
 		socket.removeListener('event:topic_moved', onTopicMoved);
 	};
 
@@ -253,6 +257,10 @@ define('forum/category/tools', [
 		return getTopicEl(tid).hasClass('locked');
 	}
 
+	// function isTopicPrivate(tid) {
+	// return getTopicEl(tid).hasClass('private');
+	// }
+
 	function isTopicPinned(tid) {
 		return getTopicEl(tid).hasClass('pinned');
 	}
@@ -269,6 +277,13 @@ define('forum/category/tools', [
 		const topic = getTopicEl(data.tid);
 		topic.toggleClass('deleted', data.isDeleted);
 		topic.find('[component="topic/locked"]').toggleClass('hidden', !data.isDeleted);
+	}
+
+	function setPrivateState(data) {
+		const topic = getTopicEl(data.tid);
+		topic.toggleClass('private', data.isPrivate);
+		topic.find('[component="topic/private"]').toggleClass('hidden', !data.isPrivate);
+		ajaxify.refresh();
 	}
 
 	function setPinnedState(data) {

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -26,6 +26,9 @@ define('forum/topic/events', [
 		'event:topic_locked': threadTools.setLockedState,
 		'event:topic_unlocked': threadTools.setLockedState,
 
+		'event:topic_private': threadTools.setPrivateState,
+		'event:topic_unprivate': threadTools.setPrivateState,
+
 		'event:topic_pinned': threadTools.setPinnedState,
 		'event:topic_unpinned': threadTools.setPinnedState,
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -51,11 +51,21 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/private"]', function () {
+			topicCommand('put', '/private', 'private');
+			return false;
+		});
+
+		topicContainer.on('click', '[component="topic/unprivate"]', function () {
+			topicCommand('del', '/private', 'unprivate');
+			return false;
+		});
+
 		topicContainer.on('click', '[component="topic/pin"]', function () {
 			topicCommand('put', '/pin', 'pin');
 			return false;
 		});
-
+  
 		topicContainer.on('click', '[component="topic/unpin"]', function () {
 			topicCommand('del', '/pin', 'unpin');
 			return false;
@@ -361,6 +371,21 @@ define('forum/topic/threadTools', [
 
 		threadEl.toggleClass('deleted', data.isDelete);
 		ajaxify.data.deleted = data.isDelete ? 1 : 0;
+
+		posts.addTopicEvents(data.events);
+	};
+
+	ThreadTools.setPrivateState = function (data) {
+		const threadEl = components.get('topic');
+		if (String(data.tid) !== threadEl.attr('data-tid')) {
+			return;
+		}
+		
+		components.get('topic/private').toggleClass('hidden', data.isPrivate).parent().attr('hidden', data.isPrivate ? '' : null);
+		components.get('topic/unprivate').toggleClass('hidden', !data.isPrivate).parent().attr('hidden', !data.isPrivate ? '' : null);
+		const icon = $('[component="topic/labels"] [component="topic/private"]');
+		icon.toggleClass('hidden', !data.isPrivate);
+		ajaxify.data.private = data.isPrivate;
 
 		posts.addTopicEvents(data.events);
 	};

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -147,10 +147,13 @@ topicsAPI.purge = async function (caller, data) {
 };
 
 topicsAPI.pin = async function (caller, { tids, expiry }) {
-	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
 
-	if (expiry) {
+	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
+	
+	// expiry is the timestamp that the "pinned" status will disappear.
+	if (expiry) { // If "expiry" is not NULL
 		await Promise.all(tids.map(async tid => topics.tools.setPinExpiry(tid, expiry, caller.uid)));
+
 	}
 };
 

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -147,7 +147,7 @@ topicsAPI.purge = async function (caller, data) {
 };
 
 topicsAPI.pin = async function (caller, { tids, expiry }) {
-
+	console.log("topicsAPI.pin\n");
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
 	
 	// expiry is the timestamp that the "pinned" status will disappear.

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -146,9 +146,19 @@ topicsAPI.purge = async function (caller, data) {
 	});
 };
 
+topicsAPI.private = async function (caller, { tids }) {
+	await doTopicAction('private', 'event:topic_private', caller, { tids });
+};
+
+topicsAPI.unprivate = async function (caller, { tids }) {
+	await doTopicAction('unprivate', 'event:topic_unprivate', caller, { tids });
+};
+
+
+// here could be when we pin a post
 topicsAPI.pin = async function (caller, { tids, expiry }) {
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
-
+	console.log('here');
 	if (expiry) {
 		await Promise.all(tids.map(async tid => topics.tools.setPinExpiry(tid, expiry, caller.uid)));
 	}

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -157,7 +157,7 @@ topicsAPI.unprivate = async function (caller, { tids }) {
 
 // here could be when we pin a post
 topicsAPI.pin = async function (caller, { tids, expiry }) {
-	console.log("topicsAPI.pin\n");
+	console.log('topicsAPI.pin\n');
 	await doTopicAction('pin', 'event:topic_pinned', caller, { tids });
 	
 	// expiry is the timestamp that the "pinned" status will disappear.

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -79,6 +79,16 @@ Topics.unpin = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Topics.private = async (req, res) => {
+	await api.topics.private(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.unprivate = async (req, res) => {
+	await api.topics.unprivate(req, { tids: [req.params.tid] });
+	helpers.formatApiResponse(200, res);
+};
+
 Topics.lock = async (req, res) => {
 	await api.topics.lock(req, { tids: [req.params.tid] });
 	helpers.formatApiResponse(200, res);

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -174,6 +174,10 @@ privsTopics.canEdit = async function (tid, uid) {
 	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
 };
 
+privsTopics.canPrivate = async function (tid, uid) {
+	return await privsTopics.isOwnerOrAdminOrMod(tid, uid);
+};
+
 privsTopics.isOwnerOrAdminOrMod = async function (tid, uid) {
 	const [isOwner, isAdminOrMod] = await Promise.all([
 		topics.isOwner(tid, uid),

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,6 +24,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
 	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
 
+	setupApiRoute(router, 'put', '/:tid/private', [...middlewares, middleware.assert.topic], controllers.write.topics.private);
+	setupApiRoute(router, 'delete', '/:tid/private', [...middlewares], controllers.write.topics.unprivate);
+
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -13,7 +13,7 @@ const intFields = [
 	'viewcount', 'postercount', 'followercount',
 	'deleted', 'locked', 'pinned', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
-	'lastposttime', 'deleterUid',
+	'lastposttime', 'deleterUid', 'private',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -49,6 +49,14 @@ Events._types = {
 		icon: 'fa-trash',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-deleted-topic'),
 	},
+	private: {
+		icon: 'fa-eye-slash',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-private'),
+	},
+	unprivate: {
+		icon: 'fa-eye',
+		translation: async (event, language) => translateSimple(event, language, 'topic:user-made-topic-public'),
+	},
 	restore: {
 		icon: 'fa-trash-o',
 		translation: async (event, language) => translateSimple(event, language, 'topic:user-restored-topic'),

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -154,7 +154,16 @@ Topics.getTopicsByTids = async function (tids, options) {
 
 	const filteredTopics = result.topics.filter(topic => topic && topic.category && !topic.category.disabled);
 
-	const hookResult = await plugins.hooks.fire('filter:topics.get', { topics: filteredTopics, uid: uid });
+
+	// MKWEE ISSUE #12: FILTER OUT PRIVATE POSTS
+	const isAdmin = await user.isAdministrator(uid);
+	const finalTopics = filteredTopics.filter((topic) => {
+		return !topic.private || isAdmin || topic.isOwner;
+	});
+
+	const hookResult = await plugins.hooks.fire('filter:topics.get', { topics: finalTopics, uid: uid });
+	// END MKWEE ISSUE #12
+
 	return hookResult.topics;
 };
 

--- a/src/views/partials/topic/topic-menu-list.tpl
+++ b/src/views/partials/topic/topic-menu-list.tpl
@@ -15,6 +15,14 @@
 	<a component="topic/unpin" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !pinned }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-thumb-tack fa-rotate-90 text-secondary"></i> [[topic:thread-tools.unpin]]</a>
 </li>
 
+<li {{{ if private }}}hidden{{{ end }}}>
+	<a component="topic/private" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye-slash text-secondary"></i> [[topic:thread-tools.private]]</a>
+</li>
+
+<li {{{ if !private }}}hidden{{{ end }}}>
+	<a component="topic/unprivate" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if !private }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-eye text-secondary"></i> [[topic:thread-tools.unprivate]]</a>
+</li>
+
 <li>
 	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
 </li>


### PR DESCRIPTION
## Summary

This PR hides "private" tagged topics from users who should not be able to see them. If a topic is private, the only users who can see it are the website admins and its creator.

### Changes

#### File modified: src/api/topics.js


### Testing

1. Rebuilt NodeBB with ./nodebb build, although this was not necessary.

2. Created an additional user: "nonadmin"

3. Created two topics - one from "admin" and one from "nonadmin"

4. Set both topics to "private" using UI changes from branch "ashley-private-posts"

5. Logged out; observed that all private topics were hidden as Guest user
6. Logged in as "admin"; observed that both private topics were visible
7. Logged in as "nonadmin"; observed that only the private topic created by "nonadmin" was visible


[Link to video demonstration](https://drive.google.com/file/d/1WZkezB6nb-2HfBX9Mj7IoJR1z150FuDh/view?usp=sharing)  used in the team presentation in the recitation

### Notes

Currently, the frontend and backend branches haven't yet been merged; we will connect frontend and backend in the next sprint.