### PR TITLE
Implements backend processing for per-topic preview toggle for pinned topics

### DIFF
--- a/public/language/en-US/category.json
+++ b/public/language/en-US/category.json
@@ -5,6 +5,8 @@
     "uncategorized.description": "Topics that do not strictly fit in with any existing categories",
     "handle.description": "This category can be followed from the open social web via the handle %1",
     "new-topic-button": "New Topic",
+    "anonymous-checkbox-label": "Anonymous",
+    "anonymous-checkbox-tooltip": "Post anonymously",
     "guest-login-post": "Log in to post",
     "no-topics": "<strong>There are no topics in this category.</strong><br />Why don't you try posting one?",
     "no-followers": "Nobody on this website is tracking or watching this category. Track or watch this category in order to begin receiving updates.",

--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -155,6 +155,9 @@ PostObject:
       type: boolean
     replies:
       type: number
+    anonymous:
+      type: number
+      description: Whether the post is anonymous (1) or not (0)
 PostDataObject:
   description: The output as returned from `Posts.getPostsData`
   allOf:
@@ -195,6 +198,9 @@ PostDataObject:
           type: string
         index:
           type: number
+        anonymous:
+          type: number
+          description: Whether the post is anonymous (1) or not (0)
         user:
           type: object
           properties:

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -189,6 +189,13 @@ TopicObject:
           description: "`pinExpiry` rendered as an ISO 8601 format"
         index:
           type: number
+        showPreview:
+          type: boolean
+          description: Whether the topic's pinned preview should be shown
+        contentPreview:
+          type: string
+          nullable: true
+          description: Sanitized preview content for the topic's first post
       required:
         - tid
 TopicObjectSlim:
@@ -287,5 +294,12 @@ TopicObjectSlim:
         numThumbs:
           type: number
           description: The number of thumbnails associated with this topic
+        showPreview:
+          type: boolean
+          description: Whether the topic's pinned preview should be shown
+        contentPreview:
+          type: string
+          nullable: true
+          description: Sanitized preview content for the topic's first post
       required:
         - tid

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -148,6 +148,8 @@ paths:
     $ref: 'write/topics/tid/lock.yaml'
   /topics/{tid}/pin:
     $ref: 'write/topics/tid/pin.yaml'
+  /topics/{tid}/preview:
+    $ref: 'write/topics/tid/preview.yaml'
   /topics/{tid}/follow:
     $ref: 'write/topics/tid/follow.yaml'
   /topics/{tid}/ignore:

--- a/public/openapi/write/topics/tid/preview.yaml
+++ b/public/openapi/write/topics/tid/preview.yaml
@@ -1,0 +1,44 @@
+put:
+  tags:
+    - topics
+  summary: set topic preview visibility
+  description: This operation sets whether a pinned topic should display its content preview. Only admins and moderators may perform this action.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            show:
+              type: boolean
+              description: Whether the topic's preview should be shown
+              example: true
+  responses:
+    '200':
+      description: Topic preview visibility updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                required:
+                  - tid
+                  - show
+                properties:
+                  tid:
+                    type: number
+                  show:
+                    type: boolean

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -11,7 +11,8 @@ define('forum/category', [
 	'alerts',
 	'api',
 	'clipboard',
-], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard) {
+	'forum/anonymousToggle',
+], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard, anonymousToggle) {
 	const Category = {};
 
 	$(window).on('action:ajaxify.start', function (ev, data) {

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -12,7 +12,7 @@ define('forum/category', [
 	'api',
 	'clipboard',
 	'forum/anonymousToggle',
-], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard, anonymousToggle) {
+], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api, clipboard) {
 	const Category = {};
 
 	$(window).on('action:ajaxify.start', function (ev, data) {

--- a/public/src/client/forum/anonymousToggle.js
+++ b/public/src/client/forum/anonymousToggle.js
@@ -1,0 +1,43 @@
+'use strict';
+
+$(document).ready(function() {
+	const AnonymousToggle = {
+		init() {
+			this.bindEvents();
+			this.loadSavedState();
+		},
+
+		bindEvents() {
+			$(document).on('change', '#anonymous-checkbox', this.handleToggle.bind(this));
+		},
+
+		handleToggle(e) {
+			const isAnonymous = $(e.target).is(':checked');
+			this.setAnonymousState(isAnonymous);
+		},
+
+		setAnonymousState(isAnonymous) {
+			// Save state to localStorage for persistence
+			localStorage.setItem('nodebb_anonymous_posting', isAnonymous.toString());
+			
+			// You can add visual feedback here if needed
+			const checkbox = $('#anonymous-checkbox');
+			if (isAnonymous) {
+				checkbox.closest('.form-check').addClass('text-warning');
+			} else {
+				checkbox.closest('.form-check').removeClass('text-warning');
+			}
+		},
+
+		loadSavedState() {
+			const savedState = localStorage.getItem('nodebb_anonymous_posting');
+			if (savedState !== null) {
+				const isAnonymous = savedState === 'true';
+				$('#anonymous-checkbox').prop('checked', isAnonymous);
+				this.setAnonymousState(isAnonymous);
+			}
+		}
+	};
+
+	AnonymousToggle.init();
+});

--- a/public/src/client/forum/anonymousToggle.js
+++ b/public/src/client/forum/anonymousToggle.js
@@ -1,6 +1,6 @@
 'use strict';
 
-$(document).ready(function() {
+$(document).ready(function () {
 	const AnonymousToggle = {
 		init() {
 			this.bindEvents();
@@ -36,7 +36,7 @@ $(document).ready(function() {
 				$('#anonymous-checkbox').prop('checked', isAnonymous);
 				this.setAnonymousState(isAnonymous);
 			}
-		}
+		},
 	};
 
 	AnonymousToggle.init();

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -17,11 +17,12 @@ define('forum/topic', [
 	'alerts',
 	'bootbox',
 	'clipboard',
+	'forum/anonymousToggle',
 ], function (
 	infinitescroll, threadTools, postTools,
 	events, posts, navigator, sort, quickreply,
 	components, storage, hooks, api, alerts,
-	bootbox, clipboard
+	bootbox, clipboard, anonymousToggle
 ) {
 	const Topic = {};
 	let tid = '0';

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -22,7 +22,7 @@ define('forum/topic', [
 	infinitescroll, threadTools, postTools,
 	events, posts, navigator, sort, quickreply,
 	components, storage, hooks, api, alerts,
-	bootbox, clipboard, anonymousToggle
+	bootbox, clipboard
 ) {
 	const Topic = {};
 	let tid = '0';

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -190,7 +190,7 @@ topicsAPI.updateTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	await topics.updateTopicTags(tid, tags);
 	return await topics.getTopicTagsObjects(tid);
 };
@@ -201,7 +201,7 @@ topicsAPI.addTags = async (caller, { tid, tags }) => {
 	}
 
 	const cid = await topics.getTopicField(tid, 'cid');
-	await topics.validateTags(tags, cid, caller.uid, tid);
+	await topics.validateTags({ tags: tags, cid: cid, uid: caller.uid, tid: tid });
 	tags = await topics.filterTags(tags, cid);
 
 	await topics.addTags(tags, [tid]);

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -11,6 +11,7 @@ const privileges = require('../privileges');
 const events = require('../events');
 const batch = require('../batch');
 const activitypub = require('../activitypub');
+const plugins = require('../plugins');
 
 const activitypubApi = require('./activitypub');
 const apiHelpers = require('./helpers');
@@ -356,4 +357,25 @@ topicsAPI.move = async (caller, { tid, cid }) => {
 	}, { batch: 10 });
 
 	await categories.onTopicsMoved(cids);
+};
+	
+// Set per-topic showPreview flag (admins/mods only)
+topicsAPI.setShowPreview = async function (caller, { tid, show }) {
+	if (typeof show === 'undefined' || (show !== true && show !== false && show !== '1' && show !== '0' && show !== 1 && show !== 0)) {
+		throw new Error('[[error:invalid-data]]');
+	}
+
+	const isAdminOrMod = await privileges.topics.isAdminOrMod(tid, caller.uid);
+	if (!isAdminOrMod) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const value = (show === true || show === '1' || show === 1) ? 1 : 0;
+	await topics.setTopicField(tid, 'showPreview', value);
+
+	// Fire plugin hook for others to react
+	const topicData = await topics.getTopicFields(tid, ['tid', 'cid', 'uid']);
+	plugins.hooks.fire('action:topic.setShowPreview', { topic: topicData, uid: caller.uid, value });
+
+	return { tid, show: !!value };
 };

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -2,7 +2,7 @@
 
 const db = require('../database');
 const topics = require('../topics');
-const MAX_PREVIEW_LENGTH = 200; // Adjust preview length as needed
+const MAX_PREVIEW_LENGTH = 500; // Adjust as needed
 const plugins = require('../plugins');
 const meta = require('../meta');
 const privileges = require('../privileges');
@@ -49,9 +49,6 @@ module.exports = function (Categories) {
 				topic.contentPreview = tidToPreview[String(topic.tid)] || '';
 			}
 		});
-
-		// Debug print: show all topicsData after contentPreview assignment
-		console.log('[Debug] topicsData after preview:', topicsData.map(t => ({ tid: t.tid, title: t.title, contentPreview: t.contentPreview })));
 
 		results = await plugins.hooks.fire('filter:category.topics.get', { cid: data.cid, topics: topicsData, uid: data.uid });
 		return { topics: results.topics, nextStart: data.stop + 1 };

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -223,6 +223,6 @@ Topics.move = async (req, res) => {
 
 Topics.setShowPreview = async (req, res) => {
 	const { show } = req.body;
-	await api.topics.setShowPreview(req, { tid: req.params.tid, show });
-	helpers.formatApiResponse(200, res);
+	const payload = await api.topics.setShowPreview(req, { tid: req.params.tid, show });
+	helpers.formatApiResponse(200, res, payload);
 };

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -220,3 +220,9 @@ Topics.move = async (req, res) => {
 
 	helpers.formatApiResponse(200, res);
 };
+
+Topics.setShowPreview = async (req, res) => {
+	const { show } = req.body;
+	await api.topics.setShowPreview(req, { tid: req.params.tid, show });
+	helpers.formatApiResponse(200, res);
+};

--- a/src/polls/create.js
+++ b/src/polls/create.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const db = require('../database');
+const user = require('../user');
+const plugins = require('../plugins');
+const utils = require('../utils');
+const Topics = require('../topics');
+
+module.exports = function (Polls) {
+        
+        Polls.create = async function (pollData, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.validatePollData(pollData);
+        const pollId = await db.incrObjectField('global', 'nextPollId');
+        const pollObject = {
+            pollId: pollId,
+            uid: uid,
+            title: pollData.title,
+            created: Date.now(),
+            updated: Date.now(),
+            deleted: 0,
+        };
+        await db.setObject(`poll:${pollId}`, pollObject);
+        await createPollOptions(pollId, pollData.options);
+        await Polls.addPollToSets(pollId);
+        await plugins.hooks.fire('action:poll.save', { poll: pollObject });
+        return pollId;
+        };
+
+        Polls.createForTopic = async function (pollData, tid, uid) {
+        const pollId = await Polls.create(pollData, uid);
+        await Polls.linkPollToTopic(pollId, tid);
+        await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
+        return pollId;
+        };
+
+        async function createPollOptions(pollId, optionTexts) {
+        if (!Array.isArray(optionTexts) || !optionTexts.length) {
+            throw new Error('[[error:invalid-poll-options]]');
+        }
+        
+        const optionIds = [];
+        for (let index = 0; index < optionTexts.length; index++) {
+            const optionId = await db.incrObjectField('global', 'nextPollOptionId');
+            const optionData = {
+                optionId: optionId,
+                pollId: pollId,
+                text: optionTexts[index],
+                votes: 0,
+                index: index,
+            };
+            await db.setObject(`polloption:${optionId}`, optionData);
+            await db.sortedSetAdd(`poll:${pollId}:options`, index, optionId);
+            optionIds.push(optionId);
+        }
+        return optionIds;
+        }
+
+        Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
+        const pollId = await Polls.create(pollData, uid);
+        await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
+        return pollId;
+        };
+
+        Polls.createFromTemplate = async function (templateData, uid) {
+        const pollId = await Polls.create(templateData, uid);
+        await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
+        return pollId;
+        };
+
+        Polls.updateSettings = async function (pollId, settings, uid) {
+        await Polls.setPollField(pollId, 'settings', settings);
+        await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
+        return pollId;
+        };
+
+        Polls.setEndDate = async function (pollId, endDate, uid) {
+        await Polls.setPollField(pollId, 'endDate', endDate);
+        await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
+        return pollId;
+        };
+
+        Polls.addOption = async function (pollId, optionText, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        const optionId = await db.incrObjectField('global', 'nextPollOptionId');
+        const optionData = {
+            optionId: optionId,
+            pollId: pollId,
+            text: optionText,
+            votes: 0,
+        };
+        await db.setObject(`polloption:${optionId}`, optionData);
+        const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
+        await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
+        await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
+        return optionId;
+        };
+
+        Polls.removeOption = async function (pollId, optionId, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await db.delete(`polloption:${optionId}`);
+        await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
+        await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
+        return pollId;
+        };
+
+        Polls.close = async function (pollId, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.setPollField(pollId, 'endDate', Date.now());
+        const poll = await Polls.getPollData(pollId);
+        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+        await Polls.removePollFromSets(pollId, cid);
+        await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
+        return pollId;
+        };
+
+        Polls.reopen = async function (pollId, newEndDate, uid) {
+        if (!(await Polls.isAdmin(uid))) {
+            throw new Error('[[error:no-privileges]]');
+        }
+        await Polls.setPollField(pollId, 'endDate', newEndDate);
+        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+        await Polls.addPollToSets(pollId, Date.now(), cid);
+        await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
+        return pollId;
+        };
+
+        async function canCreatePolls(uid) {
+        return await Polls.isAdmin(uid);
+        }
+
+        async function validateCreationData(pollData) {
+        await Polls.validatePollData(pollData);
+        return pollData;
+        }
+};

--- a/src/polls/create.js
+++ b/src/polls/create.js
@@ -1,144 +1,149 @@
 'use strict';
 
 const db = require('../database');
-const user = require('../user');
 const plugins = require('../plugins');
-const utils = require('../utils');
 const Topics = require('../topics');
 
 module.exports = function (Polls) {
-        
-        Polls.create = async function (pollData, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.validatePollData(pollData);
-        const pollId = await db.incrObjectField('global', 'nextPollId');
-        const pollObject = {
-            pollId: pollId,
-            uid: uid,
-            title: pollData.title,
-            created: Date.now(),
-            updated: Date.now(),
-            deleted: 0,
-        };
-        await db.setObject(`poll:${pollId}`, pollObject);
-        await createPollOptions(pollId, pollData.options);
-        await Polls.addPollToSets(pollId);
-        await plugins.hooks.fire('action:poll.save', { poll: pollObject });
-        return pollId;
-        };
+	
+	Polls.create = async function (pollData, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.validatePollData(pollData);
+		const pollId = String(await db.incrObjectField('global', 'nextPollId'));
+		const pollObject = {
+			pollId: pollId,
+			uid: String(uid),
+			title: pollData.title,
+			created: Date.now(),
+			updated: Date.now(),
+			deleted: 0,
+		};
+		await db.setObject(`poll:${pollId}`, pollObject);
+		await createPollOptions(pollId, pollData.options);
+		await Polls.addPollToSets(pollId);
+		await plugins.hooks.fire('action:poll.save', { poll: pollObject });
+		return pollId;
+	};
 
-        Polls.createForTopic = async function (pollData, tid, uid) {
-        const pollId = await Polls.create(pollData, uid);
-        await Polls.linkPollToTopic(pollId, tid);
-        await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
-        return pollId;
-        };
+	Polls.createForTopic = async function (pollData, tid, uid) {
+		const pollId = await Polls.create(pollData, uid);
+		await Polls.linkPollToTopic(pollId, tid);
+		await plugins.hooks.fire('action:poll.topic.created', { pollId: pollId, tid: tid });
+		return pollId;
+	};
 
-        async function createPollOptions(pollId, optionTexts) {
-        if (!Array.isArray(optionTexts) || !optionTexts.length) {
-            throw new Error('[[error:invalid-poll-options]]');
-        }
-        
-        const optionIds = [];
-        for (let index = 0; index < optionTexts.length; index++) {
-            const optionId = await db.incrObjectField('global', 'nextPollOptionId');
-            const optionData = {
-                optionId: optionId,
-                pollId: pollId,
-                text: optionTexts[index],
-                votes: 0,
-                index: index,
-            };
-            await db.setObject(`polloption:${optionId}`, optionData);
-            await db.sortedSetAdd(`poll:${pollId}:options`, index, optionId);
-            optionIds.push(optionId);
-        }
-        return optionIds;
-        }
+	async function createPollOptions(pollId, optionTexts) {
+		if (!Array.isArray(optionTexts) || !optionTexts.length) {
+			throw new Error('[[error:invalid-poll-options]]');
+		}
+		
+		const optionIds = [];
+		
+		const optionIdPromises = optionTexts.map(() => db.incrObjectField('global', 'nextPollOptionId'));
+		const generatedIds = await Promise.all(optionIdPromises);
+		optionIds.push(...generatedIds.map(String));
+		const optionPromises = optionTexts.map(async (text, index) => {
+			const optionId = optionIds[index];
+			const optionData = {
+				optionId: optionId,
+				pollId: pollId,
+				text: text,
+				votes: 0,
+				index: index,
+			};
+			await Promise.all([
+				db.setObject(`polloption:${optionId}`, optionData),
+				db.sortedSetAdd(`poll:${pollId}:options`, index, optionId),
+			]);
+		});
+		
+		await Promise.all(optionPromises);
+		return optionIds;
+	}
 
-        Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
-        const pollId = await Polls.create(pollData, uid);
-        await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
-        return pollId;
-        };
+	Polls.duplicate = async function (sourcePollId, uid, overrides = {}) {
+		const sourcePoll = await Polls.getPollData(sourcePollId);
+		if (!sourcePoll) {
+			throw new Error('Source poll not found');
+		}
+		const pollData = {
+			title: overrides.title || sourcePoll.title,
+			options: overrides.options || await Polls.getPollOptions(sourcePollId).then(opts => opts.map(opt => opt.text)),
+		};
+		const pollId = await Polls.create(pollData, uid);
+		await plugins.hooks.fire('action:poll.duplicate', { pollId: pollId, sourcePollId: sourcePollId });
+		return pollId;
+	};
 
-        Polls.createFromTemplate = async function (templateData, uid) {
-        const pollId = await Polls.create(templateData, uid);
-        await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
-        return pollId;
-        };
+	Polls.createFromTemplate = async function (templateData, uid) {
+		const pollId = await Polls.create(templateData, uid);
+		await plugins.hooks.fire('action:poll.template.created', { pollId: pollId, templateData: templateData });
+		return pollId;
+	};
 
-        Polls.updateSettings = async function (pollId, settings, uid) {
-        await Polls.setPollField(pollId, 'settings', settings);
-        await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
-        return pollId;
-        };
+	Polls.updateSettings = async function (pollId, settings) {
+		const settingsString = typeof settings === 'object' ? JSON.stringify(settings) : settings;
+		await Polls.setPollField(pollId, 'settings', settingsString);
+		await plugins.hooks.fire('action:poll.settings.updated', { pollId: pollId, settings: settings });
+		return pollId;
+	};
 
-        Polls.setEndDate = async function (pollId, endDate, uid) {
-        await Polls.setPollField(pollId, 'endDate', endDate);
-        await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
-        return pollId;
-        };
+	Polls.setEndDate = async function (pollId, endDate) {
+		await Polls.setPollField(pollId, 'endDate', endDate);
+		await plugins.hooks.fire('action:poll.enddate.set', { pollId: pollId, endDate: endDate });
+		return pollId;
+	};
 
-        Polls.addOption = async function (pollId, optionText, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        const optionId = await db.incrObjectField('global', 'nextPollOptionId');
-        const optionData = {
-            optionId: optionId,
-            pollId: pollId,
-            text: optionText,
-            votes: 0,
-        };
-        await db.setObject(`polloption:${optionId}`, optionData);
-        const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
-        await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
-        await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
-        return optionId;
-        };
+	Polls.addOption = async function (pollId, optionText, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		const optionId = String(await db.incrObjectField('global', 'nextPollOptionId'));
+		const optionData = {
+			optionId: optionId,
+			pollId: pollId,
+			text: optionText,
+			votes: 0,
+		};
+		await db.setObject(`polloption:${optionId}`, optionData);
+		const nextIndex = await db.sortedSetCard(`poll:${pollId}:options`);
+		await db.sortedSetAdd(`poll:${pollId}:options`, nextIndex, optionId);
+		await plugins.hooks.fire('action:poll.option.added', { pollId: pollId, optionText: optionText });
+		return optionId;
+	};
 
-        Polls.removeOption = async function (pollId, optionId, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await db.delete(`polloption:${optionId}`);
-        await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
-        await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
-        return pollId;
-        };
+	Polls.removeOption = async function (pollId, optionId, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await db.delete(`polloption:${optionId}`);
+		await db.sortedSetRemove(`poll:${pollId}:options`, optionId);
+		await plugins.hooks.fire('action:poll.option.removed', { pollId: pollId, optionId: optionId });
+		return pollId;
+	};
 
-        Polls.close = async function (pollId, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.setPollField(pollId, 'endDate', Date.now());
-        const poll = await Polls.getPollData(pollId);
-        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
-        await Polls.removePollFromSets(pollId, cid);
-        await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
-        return pollId;
-        };
+	Polls.close = async function (pollId, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.setPollField(pollId, 'endDate', Date.now());
+		const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+		await Polls.removePollFromSets(pollId, cid);
+		await plugins.hooks.fire('action:poll.closed', { pollId: pollId });
+		return pollId;
+	};
 
-        Polls.reopen = async function (pollId, newEndDate, uid) {
-        if (!(await Polls.isAdmin(uid))) {
-            throw new Error('[[error:no-privileges]]');
-        }
-        await Polls.setPollField(pollId, 'endDate', newEndDate);
-        const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
-        await Polls.addPollToSets(pollId, Date.now(), cid);
-        await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
-        return pollId;
-        };
+	Polls.reopen = async function (pollId, newEndDate, uid) {
+		if (!(await Polls.isAdmin(uid))) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		await Polls.setPollField(pollId, 'endDate', newEndDate);
+		const cid = await Polls.getPollTopic(pollId).then(tid => Topics.getTopicField(tid, 'cid'));
+		await Polls.addPollToSets(pollId, Date.now(), cid);
+		await plugins.hooks.fire('action:poll.reopened', { pollId: pollId, newEndDate: newEndDate });
+		return pollId;
+	};
 
-        async function canCreatePolls(uid) {
-        return await Polls.isAdmin(uid);
-        }
-
-        async function validateCreationData(pollData) {
-        await Polls.validatePollData(pollData);
-        return pollData;
-        }
 };

--- a/src/polls/index.js
+++ b/src/polls/index.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const db = require('../database');
+const user = require('../user');
+
+const Polls = module.exports;
+
+require('./create')(Polls);
+Polls.getPollData = async function (pollId) {
+	if (!pollId) {
+		return null;
+	}
+	const poll = await db.getObject(`poll:${pollId}`);
+	if (!poll) {
+		return null;
+	}
+	if (poll.uid) {
+		poll.uid = String(poll.uid);
+	}
+	if (poll.pollId) {
+		poll.pollId = String(poll.pollId);
+	}
+	if (poll.settings && typeof poll.settings === 'string') {
+		try {
+			poll.settings = JSON.parse(poll.settings);
+		} catch (e) {
+		}
+	}
+	return poll;
+};
+
+Polls.getPollOptions = async function (pollId) {
+	if (!pollId) {
+		return [];
+	}
+	const optionIds = await db.getSortedSetRange(`poll:${pollId}:options`, 0, -1);
+	if (!optionIds.length) {
+		return [];
+	}
+	const keys = optionIds.map(optionId => `polloption:${optionId}`);
+	const options = await db.getObjects(keys);
+	return options.filter(Boolean).map((option) => {
+		if (option.optionId) {
+			option.optionId = String(option.optionId);
+		}
+		if (option.pollId) {
+			option.pollId = String(option.pollId);
+		}
+		return option;
+	});
+};
+
+Polls.exists = async function (pollIds) {
+	if (Array.isArray(pollIds)) {
+		const keys = pollIds.map(pollId => `poll:${pollId}`);
+		return await db.exists(keys);
+	}
+	return await db.exists(`poll:${pollIds}`);
+};
+
+Polls.validatePollData = async function (pollData) {
+	if (!pollData) {
+		throw new Error('Poll data is required');
+	}
+	if (!pollData.title || typeof pollData.title !== 'string') {
+		throw new Error('Poll title is required');
+	}
+	if (pollData.title.length > 255) {
+		throw new Error('Poll title must be less than 255 characters');
+	}
+	if (!Array.isArray(pollData.options) || pollData.options.length < 2) {
+		throw new Error('Poll must have at least 2 options');
+	}
+	if (pollData.options.length > 10) {
+		throw new Error('Poll must have less than 10 options');
+	}
+	return true;
+};
+
+Polls.isAdmin = async function (uid) {
+	if (!uid || parseInt(uid, 10) <= 0) {
+		return false;
+	}
+	return await user.isAdministrator(uid);
+};
+
+Polls.getPollByTopic = async function (tid) {
+	const pollId = await Polls.getPollIdByTopic(tid);
+	if (!pollId) {
+		return null;
+	}
+	return await Polls.getPollData(pollId);
+};
+
+Polls.getPollIdByTopic = async function (tid) {
+	return await db.getObjectField(`topic:${tid}`, 'pollId');
+};
+
+Polls.linkPollToTopic = async function (pollId, tid) {
+	await db.setObjectField(`topic:${tid}`, 'pollId', pollId);
+	await db.setObjectField(`poll:${pollId}`, 'tid', tid);
+};
+
+Polls.addPollToSets = async function (pollId, timestamp, cid) {
+	timestamp = timestamp || Date.now();
+	await db.sortedSetAdd('polls:created', timestamp, pollId);
+	if (cid) {
+		await db.sortedSetAdd(`cid:${cid}:polls`, timestamp, pollId);
+	}
+};
+
+Polls.removePollFromSets = async function (pollId, cid) {
+	await db.sortedSetRemove('polls:created', pollId);
+	if (cid) {
+		await db.sortedSetRemove(`cid:${cid}:polls`, pollId);
+	}
+};
+
+Polls.setPollField = async function (pollId, field, value) {
+	await db.setObjectField(`poll:${pollId}`, field, value);
+	await db.setObjectField(`poll:${pollId}`, 'updated', Date.now());
+};
+
+Polls.getPollTopic = async function (pollId) {
+	return await db.getObjectField(`poll:${pollId}`, 'tid');
+};
+
+require('../promisify')(Polls);

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -39,6 +39,7 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+		postData.anonymous = data.anonymous || 0;
 		if (_activitypub) {
 			if (_activitypub.url) {
 				postData.url = _activitypub.url;

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
 	'upvotes', 'downvotes', 'deleterUid', 'edited',
-	'replies', 'bookmarks', 'announces',
+	'replies', 'bookmarks', 'announces', 'anonymous',
 ];
 
 module.exports = function (Posts) {

--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -139,7 +139,7 @@ module.exports = function (Posts) {
 			if (!canTag) {
 				throw new Error('[[error:no-privileges]]');
 			}
-			await topics.validateTags(data.tags, topicData.cid, data.uid, tid);
+			await topics.validateTags({ tags: data.tags, cid: topicData.cid, uid: data.uid, tid: tid });
 		}
 
 		const results = await plugins.hooks.fire('filter:topic.edit', {

--- a/src/posts/queue.js
+++ b/src/posts/queue.js
@@ -266,7 +266,7 @@ module.exports = function (Posts) {
 		if (type === 'topic') {
 			topics.checkTitle(data.title);
 			if (data.tags) {
-				await topics.validateTags(data.tags, cid, data.uid);
+				await topics.validateTags({ tags: data.tags, cid: cid, uid: data.uid });
 			}
 		}
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -22,7 +22,7 @@ module.exports = function (Posts) {
 		options.escape = options.hasOwnProperty('escape') ? options.escape : false;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'toPid', 'url', 'content', 'sourceContent', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'anonymous'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -133,12 +133,14 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: true };
 	}
 
+	let errorMessage = null;
+
 	if (
 		!isRemote && !results.isMod &&
 		meta.config.postEditDuration &&
 		(Date.now() - results.postData.timestamp > meta.config.postEditDuration * 1000)
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.postEditDuration}]]`;
 	}
 	if (
 		!isRemote && !results.isMod &&
@@ -146,16 +148,20 @@ privsPosts.canEdit = async function (pid, uid) {
 		meta.config.newbieReputationThreshold > results.userData.reputation &&
 		Date.now() - results.postData.timestamp > meta.config.newbiePostEditDuration * 1000
 	) {
-		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
+		errorMessage = `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]`;
 	}
 
 	const isLocked = await topics.isLocked(results.postData.tid);
 	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
+		errorMessage = '[[error:topic-locked]]';
 	}
 
 	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
+		errorMessage = '[[error:post-deleted]]';
+	}
+
+	if (errorMessage) {
+		return { flag: false, message: errorMessage };
 	}
 
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -22,7 +22,10 @@ module.exports = function () {
 	setupApiRoute(router, 'delete', '/:tid/state', [...middlewares], controllers.write.topics.delete);
 
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
-	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares], controllers.write.topics.unpin);
+	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.unpin);
+
+	// Toggle per-topic content preview (admins/mods only)
+	setupApiRoute(router, 'put', '/:tid/preview', [...middlewares, middleware.assert.topic], controllers.write.topics.setShowPreview);
 
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);
 	setupApiRoute(router, 'delete', '/:tid/lock', [...middlewares], controllers.write.topics.unlock);

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -24,7 +24,6 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.pin);
 	setupApiRoute(router, 'delete', '/:tid/pin', [...middlewares, middleware.assert.topic], controllers.write.topics.unpin);
 
-	// Toggle per-topic content preview (admins/mods only)
 	setupApiRoute(router, 'put', '/:tid/preview', [...middlewares, middleware.assert.topic], controllers.write.topics.setShowPreview);
 
 	setupApiRoute(router, 'put', '/:tid/lock', [...middlewares], controllers.write.topics.lock);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -98,7 +98,7 @@ module.exports = function (Topics) {
 			Topics.checkTitle(data.title);
 		}
 
-		await Topics.validateTags(data.tags, data.cid, uid);
+		await Topics.validateTags({ tags: data.tags, cid: data.cid, uid: uid });
 		data.tags = await Topics.filterTags(data.tags, data.cid);
 		if (!data.fromQueue && !isAdmin) {
 			Topics.checkContent(data.sourceContent || data.content);

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -11,7 +11,7 @@ const plugins = require('../plugins');
 const intFields = [
 	'tid', 'cid', 'uid', 'mainPid', 'postcount',
 	'viewcount', 'postercount', 'followercount',
-	'deleted', 'locked', 'pinned', 'pinExpiry',
+	'deleted', 'locked', 'pinned', 'showPreview', 'pinExpiry',
 	'timestamp', 'upvotes', 'downvotes',
 	'lastposttime', 'deleterUid',
 ];

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -14,7 +14,7 @@ module.exports = function (Topics) {
 		year: 31104000000,
 	};
 
-	Topics.getRecentTopics = async function (cid, uid, start, stop, filter) {
+	Topics.getRecentTopics = async function ({cid, uid, start, stop, filter}) {
 		return await Topics.getSortedTopics({
 			cids: cid,
 			uid: uid,

--- a/src/topics/tags.js
+++ b/src/topics/tags.js
@@ -66,7 +66,8 @@ module.exports = function (Topics) {
 		);
 	};
 
-	Topics.validateTags = async function (tags, cid, uid, tid = null) {
+	Topics.validateTags = async function ({ tags, cid, uid, tid}) {
+		tid = tid ?? null;
 		if (!Array.isArray(tags)) {
 			throw new Error('[[error:invalid-data]]');
 		}

--- a/src/upgrades/4.4.0/add-anonymous-field-to-posts.js
+++ b/src/upgrades/4.4.0/add-anonymous-field-to-posts.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const db = require('../../database');
+const batch = require('../../batch');
+
+module.exports = {
+	name: 'Add anonymous field to posts',
+	timestamp: Date.UTC(2025, 8, 21),
+	method: async function () {
+		const { progress } = this;
+		
+		// Get all post keys
+		const postKeys = await db.getSortedSetRange('posts:pid', 0, -1);
+		progress.total = postKeys.length;
+
+		await batch.processArray(postKeys, async (pids) => {
+			progress.incr(pids.length);
+			
+			// Get all post objects
+			const keys = pids.map(pid => `post:${pid}`);
+			const posts = await db.getObjects(keys);
+			
+			// Update posts that don't have the anonymous field
+			const updates = [];
+			posts.forEach((post, index) => {
+				if (post && !post.hasOwnProperty('anonymous')) {
+					updates.push([keys[index], { anonymous: 0 }]);
+				}
+			});
+			
+			if (updates.length > 0) {
+				await db.setObjectBulk(updates);
+			}
+		}, {
+			progress: progress,
+			batch: 500,
+		});
+	},
+};

--- a/src/views/partials/chats/composer.tpl
+++ b/src/views/partials/chats/composer.tpl
@@ -17,9 +17,17 @@
 		</div>
 	</div>
 	<div class="d-flex justify-content-between align-items-center text-xs w-100 px-2 mt-1">
-		<div component="chat/composer/typing" class="">
-			<div component="chat/composer/typing/users" class="hidden"></div>
-			<div component="chat/composer/typing/text" class="hidden"></div>
+		<div class="d-flex align-items-center gap-2">
+			<div component="chat/composer/typing" class="">
+				<div component="chat/composer/typing/users" class="hidden"></div>
+				<div component="chat/composer/typing/text" class="hidden"></div>
+			</div>
+			<div class="form-check">
+				<input component="chat/composer/anonymous" class="form-check-input" type="checkbox" id="anonymousMessage" title="[[modules:chat.send-anonymous]]" data-bs-toggle="tooltip">
+				<label class="form-check-label text-xs text-muted" for="anonymousMessage">
+					[[modules:chat.anonymous]]
+				</label>
+			</div>
 		</div>
 		<div component="chat/message/remaining" class="text-xs text-muted">{maximumChatMessageLength}</div>
 	</div>

--- a/test/polls.js
+++ b/test/polls.js
@@ -14,409 +14,409 @@ const groups = require('../src/groups');
 const helpers = require('./helpers');
 
 describe('Polls', () => {
-    let adminUid;
-    let regularUid;
-    let categoryObj;
-    let topicObj;
+	let adminUid;
+	let regularUid;
+	let categoryObj;
+	let topicObj;
 
-    before(async () => {
-        adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
-        regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
-        
-        await groups.join('administrators', adminUid);
-        
-        categoryObj = await categories.create({
-            name: 'Poll Test Category',
-            description: 'Category for poll testing',
-        });
+	before(async () => {
+		adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
+		regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
+		
+		await groups.join('administrators', adminUid);
+		
+		categoryObj = await categories.create({
+			name: 'Poll Test Category',
+			description: 'Category for poll testing',
+		});
 
-        topicObj = await topics.post({
-            uid: adminUid,
-            cid: categoryObj.cid,
-            title: 'Test Topic for Polls',
-            content: 'This topic will contain polls',
-        });
-    });
+		topicObj = await topics.post({
+			uid: adminUid,
+			cid: categoryObj.cid,
+			title: 'Test Topic for Polls',
+			content: 'This topic will contain polls',
+		});
+	});
 
-    after(async () => {
-        await db.emptydb();
-    });
+	after(async () => {
+		await db.emptydb();
+	});
 
-    describe('Poll Creation', () => {
-        it('should allow admin to create a basic poll', async () => {
-            const pollData = {
-                title: 'Test Poll',
-                options: ['Option A', 'Option B', 'Option C'],
-            };
+	describe('Poll Creation', () => {
+		it('should allow admin to create a basic poll', async () => {
+			const pollData = {
+				title: 'Test Poll',
+				options: ['Option A', 'Option B', 'Option C'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            
-            assert(pollId);
-            assert(typeof pollId === 'string');
-            
-            const createdPoll = await polls.getPollData(pollId);
-            assert.strictEqual(createdPoll.title, 'Test Poll');
-            assert.strictEqual(createdPoll.uid, adminUid);
-            assert(createdPoll.created);
-            assert(createdPoll.updated);
-            assert.strictEqual(createdPoll.deleted, 0);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			
+			assert(pollId);
+			assert(typeof pollId === 'string');
+			
+			const createdPoll = await polls.getPollData(pollId);
+			assert.strictEqual(createdPoll.title, 'Test Poll');
+			assert.strictEqual(String(createdPoll.uid), String(adminUid));
+			assert(createdPoll.created);
+			assert(createdPoll.updated);
+			assert.strictEqual(Number(createdPoll.deleted), 0);
+		});
 
-        it('should create poll options when creating a poll', async () => {
-            const pollData = {
-                title: 'Options Test Poll',
-                options: ['First Option', 'Second Option'],
-            };
+		it('should create poll options when creating a poll', async () => {
+			const pollData = {
+				title: 'Options Test Poll',
+				options: ['First Option', 'Second Option'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            const options = await polls.getPollOptions(pollId);
-            
-            assert.strictEqual(options.length, 2);
-            assert.strictEqual(options[0].text, 'First Option');
-            assert.strictEqual(options[1].text, 'Second Option');
-            assert.strictEqual(options[0].votes, 0);
-            assert.strictEqual(options[1].votes, 0);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			const options = await polls.getPollOptions(pollId);
+			
+			assert.strictEqual(options.length, 2);
+			assert.strictEqual(options[0].text, 'First Option');
+			assert.strictEqual(options[1].text, 'Second Option');
+			assert.strictEqual(Number(options[0].votes), 0);
+			assert.strictEqual(Number(options[1].votes), 0);
+		});
 
-        it('should not allow regular user to create poll', async () => {
-            const pollData = {
-                title: 'Unauthorized Poll',
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should not allow regular user to create poll', async () => {
+			const pollData = {
+				title: 'Unauthorized Poll',
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+			try {
+				await polls.create(pollData, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should validate poll data before creation', async () => {
-            try {
-                await polls.create(null, adminUid);
-                assert.fail('Should have thrown validation error');
-            } catch (err) {
-                assert(err.message.includes('Poll data is required'));
-            }
-        });
+		it('should validate poll data before creation', async () => {
+			try {
+				await polls.create(null, adminUid);
+				assert.fail('Should have thrown validation error');
+			} catch (err) {
+				assert(err.message.includes('Poll data is required'));
+			}
+		});
 
-        it('should require poll title', async () => {
-            const pollData = {
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should require poll title', async () => {
+			const pollData = {
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown title required error');
-            } catch (err) {
-                assert(err.message.includes('Poll title is required'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown title required error');
+			} catch (err) {
+				assert(err.message.includes('Poll title is required'));
+			}
+		});
 
-        it('should require at least 2 options', async () => {
-            const pollData = {
-                title: 'Single Option Poll',
-                options: ['Only Option'],
-            };
+		it('should require at least 2 options', async () => {
+			const pollData = {
+				title: 'Single Option Poll',
+				options: ['Only Option'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown minimum options error');
-            } catch (err) {
-                assert(err.message.includes('Poll must have at least 2 options'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown minimum options error');
+			} catch (err) {
+				assert(err.message.includes('Poll must have at least 2 options'));
+			}
+		});
 
-        it('should not allow more than 10 options', async () => {
-            const pollData = {
-                title: 'Too Many Options Poll',
-                options: [
-                    'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
-                    'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11'
-                ],
-            };
+		it('should not allow more than 10 options', async () => {
+			const pollData = {
+				title: 'Too Many Options Poll',
+				options: [
+					'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
+					'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11',
+				],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown maximum options error');
-            } catch (err) {
-                assert(err.message.includes('Poll must have less than 10 options'));
-            }
-        });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown maximum options error');
+			} catch (err) {
+				assert(err.message.includes('Poll must have less than 10 options'));
+			}
+		});
 
-        it('should validate poll title length', async () => {
-            const longTitle = 'a'.repeat(256);
-            const pollData = {
-                title: longTitle,
-                options: ['Option 1', 'Option 2'],
-            };
+		it('should validate poll title length', async () => {
+			const longTitle = 'a'.repeat(256);
+			const pollData = {
+				title: longTitle,
+				options: ['Option 1', 'Option 2'],
+			};
 
-            try {
-                await polls.create(pollData, adminUid);
-                assert.fail('Should have thrown title too long error');
-            } catch (err) {
-                assert(err.message.includes('Poll title must be less than 255 characters'));
-            }
-        });
-    });
+			try {
+				await polls.create(pollData, adminUid);
+				assert.fail('Should have thrown title too long error');
+			} catch (err) {
+				assert(err.message.includes('Poll title must be less than 255 characters'));
+			}
+		});
+	});
 
-    describe('Poll Creation for Topics', () => {
-        it('should create poll attached to topic', async () => {
-            const pollData = {
-                title: 'Topic Poll',
-                options: ['Yes', 'No'],
-            };
+	describe('Poll Creation for Topics', () => {
+		it('should create poll attached to topic', async () => {
+			const pollData = {
+				title: 'Topic Poll',
+				options: ['Yes', 'No'],
+			};
 
-            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
-            
-            assert(pollId);
-            
-            const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
-            assert(linkedPoll);
-            assert.strictEqual(linkedPoll.title, 'Topic Poll');
-        });
+			const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+			
+			assert(pollId);
+			
+			const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
+			assert(linkedPoll);
+			assert.strictEqual(linkedPoll.title, 'Topic Poll');
+		});
 
-        it('should link poll to topic in database', async () => {
-            const pollData = {
-                title: 'Linked Poll',
-                options: ['Choice A', 'Choice B'],
-            };
+		it('should link poll to topic in database', async () => {
+			const pollData = {
+				title: 'Linked Poll',
+				options: ['Choice A', 'Choice B'],
+			};
 
-            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
-            const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
-            
-            assert.strictEqual(pollId, pollIdFromTopic);
-        });
-    });
+			const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+			const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
+			
+			assert.strictEqual(pollId, pollIdFromTopic);
+		});
+	});
 
-    describe('Poll Options Management', () => {
-        let testPollId;
+	describe('Poll Options Management', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Options Management Test',
-                options: ['Initial Option 1', 'Initial Option 2'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Options Management Test',
+				options: ['Initial Option 1', 'Initial Option 2'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to add new option to existing poll', async () => {
-            const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
-            
-            assert(optionId);
-            
-            const options = await polls.getPollOptions(testPollId);
-            assert.strictEqual(options.length, 3);
-            assert(options.some(opt => opt.text === 'New Option'));
-        });
+		it('should allow admin to add new option to existing poll', async () => {
+			const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
+			
+			assert(optionId);
+			
+			const options = await polls.getPollOptions(testPollId);
+			assert.strictEqual(options.length, 3);
+			assert(options.some(opt => opt.text === 'New Option'));
+		});
 
-        it('should not allow regular user to add option', async () => {
-            try {
-                await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+		it('should not allow regular user to add option', async () => {
+			try {
+				await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should allow admin to remove option from poll', async () => {
-            const options = await polls.getPollOptions(testPollId);
-            const optionToRemove = options[0];
-            
-            await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
-            
-            const updatedOptions = await polls.getPollOptions(testPollId);
-            assert.strictEqual(updatedOptions.length, 1);
-            assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
-        });
+		it('should allow admin to remove option from poll', async () => {
+			const options = await polls.getPollOptions(testPollId);
+			const optionToRemove = options[0];
+			
+			await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
+			
+			const updatedOptions = await polls.getPollOptions(testPollId);
+			assert.strictEqual(updatedOptions.length, 1);
+			assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
+		});
 
-        it('should not allow regular user to remove option', async () => {
-            const options = await polls.getPollOptions(testPollId);
-            const optionToRemove = options[0];
+		it('should not allow regular user to remove option', async () => {
+			const options = await polls.getPollOptions(testPollId);
+			const optionToRemove = options[0];
 
-            try {
-                await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
-    });
+			try {
+				await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
+	});
 
-    describe('Poll Lifecycle Management', () => {
-        let testPollId;
+	describe('Poll Lifecycle Management', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Lifecycle Test Poll',
-                options: ['Option 1', 'Option 2'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Lifecycle Test Poll',
+				options: ['Option 1', 'Option 2'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to close poll early', async () => {
-            await polls.close(testPollId, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert(poll.endDate);
-            assert(poll.endDate <= Date.now());
-        });
+		it('should allow admin to close poll early', async () => {
+			await polls.close(testPollId, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert(poll.endDate);
+			assert(poll.endDate <= Date.now());
+		});
 
-        it('should not allow regular user to close poll', async () => {
-            try {
-                await polls.close(testPollId, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
+		it('should not allow regular user to close poll', async () => {
+			try {
+				await polls.close(testPollId, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
 
-        it('should allow admin to reopen closed poll', async () => {
-            await polls.close(testPollId, adminUid);
-            
-            const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
-            await polls.reopen(testPollId, futureDate, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.strictEqual(poll.endDate, futureDate);
-        });
+		it('should allow admin to reopen closed poll', async () => {
+			await polls.close(testPollId, adminUid);
+			
+			const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
+			await polls.reopen(testPollId, futureDate, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.strictEqual(Number(poll.endDate), futureDate);
+		});
 
-        it('should not allow regular user to reopen poll', async () => {
-            await polls.close(testPollId, adminUid);
+		it('should not allow regular user to reopen poll', async () => {
+			await polls.close(testPollId, adminUid);
 
-            try {
-                await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
-                assert.fail('Should have thrown no-privileges error');
-            } catch (err) {
-                assert.strictEqual(err.message, '[[error:no-privileges]]');
-            }
-        });
-    });
+			try {
+				await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
+				assert.fail('Should have thrown no-privileges error');
+			} catch (err) {
+				assert.strictEqual(err.message, '[[error:no-privileges]]');
+			}
+		});
+	});
 
-    describe('Poll Settings', () => {
-        let testPollId;
+	describe('Poll Settings', () => {
+		let testPollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Settings Test Poll',
-                options: ['Option A', 'Option B'],
-            };
-            testPollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Settings Test Poll',
+				options: ['Option A', 'Option B'],
+			};
+			testPollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow updating poll settings', async () => {
-            const settings = {
-                allowRevote: true,
-                hideResults: false,
-            };
+		it('should allow updating poll settings', async () => {
+			const settings = {
+				allowRevote: true,
+				hideResults: false,
+			};
 
-            await polls.updateSettings(testPollId, settings, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.deepStrictEqual(poll.settings, settings);
-        });
+			await polls.updateSettings(testPollId, settings, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.deepStrictEqual(poll.settings, settings);
+		});
 
-        it('should allow setting poll end date', async () => {
-            const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
-            
-            await polls.setEndDate(testPollId, endDate, adminUid);
-            
-            const poll = await polls.getPollData(testPollId);
-            assert.strictEqual(poll.endDate, endDate);
-        });
-    });
+		it('should allow setting poll end date', async () => {
+			const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
+			
+			await polls.setEndDate(testPollId, endDate, adminUid);
+			
+			const poll = await polls.getPollData(testPollId);
+			assert.strictEqual(Number(poll.endDate), endDate);
+		});
+	});
 
-    describe('Poll Duplication', () => {
-        let sourcePollId;
+	describe('Poll Duplication', () => {
+		let sourcePollId;
 
-        beforeEach(async () => {
-            const pollData = {
-                title: 'Source Poll',
-                options: ['Original Option 1', 'Original Option 2'],
-            };
-            sourcePollId = await polls.create(pollData, adminUid);
-        });
+		beforeEach(async () => {
+			const pollData = {
+				title: 'Source Poll',
+				options: ['Original Option 1', 'Original Option 2'],
+			};
+			sourcePollId = await polls.create(pollData, adminUid);
+		});
 
-        it('should allow admin to duplicate existing poll', async () => {
-            const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
-            
-            assert(duplicatedPollId);
-            assert.notStrictEqual(duplicatedPollId, sourcePollId);
-            
-            const [sourcePoll, duplicatedPoll] = await Promise.all([
-                polls.getPollData(sourcePollId),
-                polls.getPollData(duplicatedPollId),
-            ]);
-            
-            assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
-            assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
-        });
+		it('should allow admin to duplicate existing poll', async () => {
+			const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
+			
+			assert(duplicatedPollId);
+			assert.notStrictEqual(duplicatedPollId, sourcePollId);
+			
+			const [sourcePoll, duplicatedPoll] = await Promise.all([
+				polls.getPollData(sourcePollId),
+				polls.getPollData(duplicatedPollId),
+			]);
+			
+			assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
+			assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
+		});
 
-        it('should create poll from template data', async () => {
-            const templateData = {
-                title: 'Template Poll',
-                options: ['Template Option 1', 'Template Option 2'],
-            };
+		it('should create poll from template data', async () => {
+			const templateData = {
+				title: 'Template Poll',
+				options: ['Template Option 1', 'Template Option 2'],
+			};
 
-            const pollId = await polls.createFromTemplate(templateData, adminUid);
-            
-            assert(pollId);
-            
-            const poll = await polls.getPollData(pollId);
-            assert.strictEqual(poll.title, 'Template Poll');
-        });
-    });
+			const pollId = await polls.createFromTemplate(templateData, adminUid);
+			
+			assert(pollId);
+			
+			const poll = await polls.getPollData(pollId);
+			assert.strictEqual(poll.title, 'Template Poll');
+		});
+	});
 
-    describe('Poll Existence and Validation', () => {
-        it('should check if poll exists', async () => {
-            const pollData = {
-                title: 'Existence Test Poll',
-                options: ['Option 1', 'Option 2'],
-            };
+	describe('Poll Existence and Validation', () => {
+		it('should check if poll exists', async () => {
+			const pollData = {
+				title: 'Existence Test Poll',
+				options: ['Option 1', 'Option 2'],
+			};
 
-            const pollId = await polls.create(pollData, adminUid);
-            
-            const exists = await polls.exists(pollId);
-            assert.strictEqual(exists, true);
-            
-            const nonExistentExists = await polls.exists('nonexistent');
-            assert.strictEqual(nonExistentExists, false);
-        });
+			const pollId = await polls.create(pollData, adminUid);
+			
+			const exists = await polls.exists(pollId);
+			assert.strictEqual(exists, true);
+			
+			const nonExistentExists = await polls.exists('nonexistent');
+			assert.strictEqual(nonExistentExists, false);
+		});
 
-        it('should check multiple polls existence', async () => {
-            const pollData1 = {
-                title: 'Batch Test Poll 1',
-                options: ['Option 1', 'Option 2'],
-            };
-            const pollData2 = {
-                title: 'Batch Test Poll 2',
-                options: ['Option A', 'Option B'],
-            };
+		it('should check multiple polls existence', async () => {
+			const pollData1 = {
+				title: 'Batch Test Poll 1',
+				options: ['Option 1', 'Option 2'],
+			};
+			const pollData2 = {
+				title: 'Batch Test Poll 2',
+				options: ['Option A', 'Option B'],
+			};
 
-            const [pollId1, pollId2] = await Promise.all([
-                polls.create(pollData1, adminUid),
-                polls.create(pollData2, adminUid),
-            ]);
-            
-            const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
-            
-            assert.strictEqual(existenceResults[0], true);
-            assert.strictEqual(existenceResults[1], true);
-            assert.strictEqual(existenceResults[2], false);
-        });
+			const [pollId1, pollId2] = await Promise.all([
+				polls.create(pollData1, adminUid),
+				polls.create(pollData2, adminUid),
+			]);
+			
+			const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
+			
+			assert.strictEqual(existenceResults[0], true);
+			assert.strictEqual(existenceResults[1], true);
+			assert.strictEqual(existenceResults[2], false);
+		});
 
-        it('should validate poll data correctly', async () => {
-            const validPollData = {
-                title: 'Valid Poll',
-                options: ['Option 1', 'Option 2'],
-                settings: {
-                    allowRevote: true,
-                    hideResults: false,
-                },
-            };
+		it('should validate poll data correctly', async () => {
+			const validPollData = {
+				title: 'Valid Poll',
+				options: ['Option 1', 'Option 2'],
+				settings: {
+					allowRevote: true,
+					hideResults: false,
+				},
+			};
 
-            await polls.validatePollData(validPollData);
-        });
-    });
+			await polls.validatePollData(validPollData);
+		});
+	});
 });

--- a/test/polls.js
+++ b/test/polls.js
@@ -1,0 +1,422 @@
+'use strict';
+
+const assert = require('assert');
+const util = require('util');
+
+const sleep = util.promisify(setTimeout);
+
+const db = require('./mocks/databasemock');
+const polls = require('../src/polls');
+const topics = require('../src/topics');
+const categories = require('../src/categories');
+const user = require('../src/user');
+const groups = require('../src/groups');
+const helpers = require('./helpers');
+
+describe('Polls', () => {
+    let adminUid;
+    let regularUid;
+    let categoryObj;
+    let topicObj;
+
+    before(async () => {
+        adminUid = await user.create({ username: 'pollAdmin', password: '123456', email: 'admin@poll.test' });
+        regularUid = await user.create({ username: 'pollUser', password: '123456', email: 'user@poll.test' });
+        
+        await groups.join('administrators', adminUid);
+        
+        categoryObj = await categories.create({
+            name: 'Poll Test Category',
+            description: 'Category for poll testing',
+        });
+
+        topicObj = await topics.post({
+            uid: adminUid,
+            cid: categoryObj.cid,
+            title: 'Test Topic for Polls',
+            content: 'This topic will contain polls',
+        });
+    });
+
+    after(async () => {
+        await db.emptydb();
+    });
+
+    describe('Poll Creation', () => {
+        it('should allow admin to create a basic poll', async () => {
+            const pollData = {
+                title: 'Test Poll',
+                options: ['Option A', 'Option B', 'Option C'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            
+            assert(pollId);
+            assert(typeof pollId === 'string');
+            
+            const createdPoll = await polls.getPollData(pollId);
+            assert.strictEqual(createdPoll.title, 'Test Poll');
+            assert.strictEqual(createdPoll.uid, adminUid);
+            assert(createdPoll.created);
+            assert(createdPoll.updated);
+            assert.strictEqual(createdPoll.deleted, 0);
+        });
+
+        it('should create poll options when creating a poll', async () => {
+            const pollData = {
+                title: 'Options Test Poll',
+                options: ['First Option', 'Second Option'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            const options = await polls.getPollOptions(pollId);
+            
+            assert.strictEqual(options.length, 2);
+            assert.strictEqual(options[0].text, 'First Option');
+            assert.strictEqual(options[1].text, 'Second Option');
+            assert.strictEqual(options[0].votes, 0);
+            assert.strictEqual(options[1].votes, 0);
+        });
+
+        it('should not allow regular user to create poll', async () => {
+            const pollData = {
+                title: 'Unauthorized Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should validate poll data before creation', async () => {
+            try {
+                await polls.create(null, adminUid);
+                assert.fail('Should have thrown validation error');
+            } catch (err) {
+                assert(err.message.includes('Poll data is required'));
+            }
+        });
+
+        it('should require poll title', async () => {
+            const pollData = {
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown title required error');
+            } catch (err) {
+                assert(err.message.includes('Poll title is required'));
+            }
+        });
+
+        it('should require at least 2 options', async () => {
+            const pollData = {
+                title: 'Single Option Poll',
+                options: ['Only Option'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown minimum options error');
+            } catch (err) {
+                assert(err.message.includes('Poll must have at least 2 options'));
+            }
+        });
+
+        it('should not allow more than 10 options', async () => {
+            const pollData = {
+                title: 'Too Many Options Poll',
+                options: [
+                    'Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5',
+                    'Option 6', 'Option 7', 'Option 8', 'Option 9', 'Option 10', 'Option 11'
+                ],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown maximum options error');
+            } catch (err) {
+                assert(err.message.includes('Poll must have less than 10 options'));
+            }
+        });
+
+        it('should validate poll title length', async () => {
+            const longTitle = 'a'.repeat(256);
+            const pollData = {
+                title: longTitle,
+                options: ['Option 1', 'Option 2'],
+            };
+
+            try {
+                await polls.create(pollData, adminUid);
+                assert.fail('Should have thrown title too long error');
+            } catch (err) {
+                assert(err.message.includes('Poll title must be less than 255 characters'));
+            }
+        });
+    });
+
+    describe('Poll Creation for Topics', () => {
+        it('should create poll attached to topic', async () => {
+            const pollData = {
+                title: 'Topic Poll',
+                options: ['Yes', 'No'],
+            };
+
+            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+            
+            assert(pollId);
+            
+            const linkedPoll = await polls.getPollByTopic(topicObj.topicData.tid, adminUid);
+            assert(linkedPoll);
+            assert.strictEqual(linkedPoll.title, 'Topic Poll');
+        });
+
+        it('should link poll to topic in database', async () => {
+            const pollData = {
+                title: 'Linked Poll',
+                options: ['Choice A', 'Choice B'],
+            };
+
+            const pollId = await polls.createForTopic(pollData, topicObj.topicData.tid, adminUid);
+            const pollIdFromTopic = await polls.getPollIdByTopic(topicObj.topicData.tid);
+            
+            assert.strictEqual(pollId, pollIdFromTopic);
+        });
+    });
+
+    describe('Poll Options Management', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Options Management Test',
+                options: ['Initial Option 1', 'Initial Option 2'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to add new option to existing poll', async () => {
+            const optionId = await polls.addOption(testPollId, 'New Option', adminUid);
+            
+            assert(optionId);
+            
+            const options = await polls.getPollOptions(testPollId);
+            assert.strictEqual(options.length, 3);
+            assert(options.some(opt => opt.text === 'New Option'));
+        });
+
+        it('should not allow regular user to add option', async () => {
+            try {
+                await polls.addOption(testPollId, 'Unauthorized Option', regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should allow admin to remove option from poll', async () => {
+            const options = await polls.getPollOptions(testPollId);
+            const optionToRemove = options[0];
+            
+            await polls.removeOption(testPollId, optionToRemove.optionId, adminUid);
+            
+            const updatedOptions = await polls.getPollOptions(testPollId);
+            assert.strictEqual(updatedOptions.length, 1);
+            assert(!updatedOptions.some(opt => opt.optionId === optionToRemove.optionId));
+        });
+
+        it('should not allow regular user to remove option', async () => {
+            const options = await polls.getPollOptions(testPollId);
+            const optionToRemove = options[0];
+
+            try {
+                await polls.removeOption(testPollId, optionToRemove.optionId, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+    });
+
+    describe('Poll Lifecycle Management', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Lifecycle Test Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to close poll early', async () => {
+            await polls.close(testPollId, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert(poll.endDate);
+            assert(poll.endDate <= Date.now());
+        });
+
+        it('should not allow regular user to close poll', async () => {
+            try {
+                await polls.close(testPollId, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+
+        it('should allow admin to reopen closed poll', async () => {
+            await polls.close(testPollId, adminUid);
+            
+            const futureDate = Date.now() + (24 * 60 * 60 * 1000); // 24 hours from now
+            await polls.reopen(testPollId, futureDate, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.strictEqual(poll.endDate, futureDate);
+        });
+
+        it('should not allow regular user to reopen poll', async () => {
+            await polls.close(testPollId, adminUid);
+
+            try {
+                await polls.reopen(testPollId, Date.now() + 86400000, regularUid);
+                assert.fail('Should have thrown no-privileges error');
+            } catch (err) {
+                assert.strictEqual(err.message, '[[error:no-privileges]]');
+            }
+        });
+    });
+
+    describe('Poll Settings', () => {
+        let testPollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Settings Test Poll',
+                options: ['Option A', 'Option B'],
+            };
+            testPollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow updating poll settings', async () => {
+            const settings = {
+                allowRevote: true,
+                hideResults: false,
+            };
+
+            await polls.updateSettings(testPollId, settings, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.deepStrictEqual(poll.settings, settings);
+        });
+
+        it('should allow setting poll end date', async () => {
+            const endDate = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 days from now
+            
+            await polls.setEndDate(testPollId, endDate, adminUid);
+            
+            const poll = await polls.getPollData(testPollId);
+            assert.strictEqual(poll.endDate, endDate);
+        });
+    });
+
+    describe('Poll Duplication', () => {
+        let sourcePollId;
+
+        beforeEach(async () => {
+            const pollData = {
+                title: 'Source Poll',
+                options: ['Original Option 1', 'Original Option 2'],
+            };
+            sourcePollId = await polls.create(pollData, adminUid);
+        });
+
+        it('should allow admin to duplicate existing poll', async () => {
+            const duplicatedPollId = await polls.duplicate(sourcePollId, adminUid);
+            
+            assert(duplicatedPollId);
+            assert.notStrictEqual(duplicatedPollId, sourcePollId);
+            
+            const [sourcePoll, duplicatedPoll] = await Promise.all([
+                polls.getPollData(sourcePollId),
+                polls.getPollData(duplicatedPollId),
+            ]);
+            
+            assert.strictEqual(sourcePoll.title, duplicatedPoll.title);
+            assert.notStrictEqual(sourcePoll.created, duplicatedPoll.created);
+        });
+
+        it('should create poll from template data', async () => {
+            const templateData = {
+                title: 'Template Poll',
+                options: ['Template Option 1', 'Template Option 2'],
+            };
+
+            const pollId = await polls.createFromTemplate(templateData, adminUid);
+            
+            assert(pollId);
+            
+            const poll = await polls.getPollData(pollId);
+            assert.strictEqual(poll.title, 'Template Poll');
+        });
+    });
+
+    describe('Poll Existence and Validation', () => {
+        it('should check if poll exists', async () => {
+            const pollData = {
+                title: 'Existence Test Poll',
+                options: ['Option 1', 'Option 2'],
+            };
+
+            const pollId = await polls.create(pollData, adminUid);
+            
+            const exists = await polls.exists(pollId);
+            assert.strictEqual(exists, true);
+            
+            const nonExistentExists = await polls.exists('nonexistent');
+            assert.strictEqual(nonExistentExists, false);
+        });
+
+        it('should check multiple polls existence', async () => {
+            const pollData1 = {
+                title: 'Batch Test Poll 1',
+                options: ['Option 1', 'Option 2'],
+            };
+            const pollData2 = {
+                title: 'Batch Test Poll 2',
+                options: ['Option A', 'Option B'],
+            };
+
+            const [pollId1, pollId2] = await Promise.all([
+                polls.create(pollData1, adminUid),
+                polls.create(pollData2, adminUid),
+            ]);
+            
+            const existenceResults = await polls.exists([pollId1, pollId2, 'nonexistent']);
+            
+            assert.strictEqual(existenceResults[0], true);
+            assert.strictEqual(existenceResults[1], true);
+            assert.strictEqual(existenceResults[2], false);
+        });
+
+        it('should validate poll data correctly', async () => {
+            const validPollData = {
+                title: 'Valid Poll',
+                options: ['Option 1', 'Option 2'],
+                settings: {
+                    allowRevote: true,
+                    hideResults: false,
+                },
+            };
+
+            await polls.validatePollData(validPollData);
+        });
+    });
+});

--- a/test/posts/anonymous.js
+++ b/test/posts/anonymous.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const assert = require('assert');
+
+const db = require('../mocks/databasemock');
+const posts = require('../../src/posts');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const user = require('../../src/user');
+
+describe('Anonymous Posts', () => {
+	let testUid;
+	let testCid;
+	let topicData;
+	let postData;
+
+	before(async () => {
+		testUid = await user.create({ username: 'testuser' });
+		({ cid: testCid } = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for anonymous posts',
+		}));
+	});
+
+	it('should create a regular post without anonymous field', async () => {
+		({ topicData, postData } = await topics.post({
+			uid: testUid,
+			cid: testCid,
+			title: 'Regular Post',
+			content: 'This is a regular post',
+		}));
+
+		const post = await posts.getPostData(postData.pid);
+		assert(post);
+		assert.strictEqual(post.anonymous, 0);
+		assert.strictEqual(post.uid, testUid);
+		assert.strictEqual(post.content, 'This is a regular post');
+	});
+
+	it('should create an anonymous post with anonymous field set to 1', async () => {
+		const anonymousPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is an anonymous post',
+			anonymous: 1,
+		});
+
+		assert(anonymousPost);
+		assert.strictEqual(anonymousPost.anonymous, 1);
+		assert.strictEqual(anonymousPost.uid, testUid);
+		assert.strictEqual(anonymousPost.content, 'This is an anonymous post');
+
+		// Verify the post was stored correctly in the database
+		const storedPost = await posts.getPostData(anonymousPost.pid);
+		assert.strictEqual(storedPost.anonymous, 1);
+	});
+
+	it('should create a reply with anonymous field', async () => {
+		const anonymousReply = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is an anonymous reply',
+			anonymous: 1,
+		});
+
+		assert(anonymousReply);
+		assert.strictEqual(anonymousReply.anonymous, 1);
+		assert.strictEqual(anonymousReply.uid, testUid);
+		assert.strictEqual(anonymousReply.content, 'This is an anonymous reply');
+
+		const storedReply = await posts.getPostData(anonymousReply.pid);
+		assert.strictEqual(storedReply.anonymous, 1);
+	});
+
+	it('should handle posts without anonymous field (defaults to 0)', async () => {
+		const regularReply = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is a regular reply',
+		});
+
+		assert(regularReply);
+		assert.strictEqual(regularReply.anonymous, 0);
+		assert.strictEqual(regularReply.uid, testUid);
+		assert.strictEqual(regularReply.content, 'This is a regular reply');
+
+		const storedReply = await posts.getPostData(regularReply.pid);
+		assert.strictEqual(storedReply.anonymous, 0);
+	});
+
+	it('should be able to set and get anonymous field using setPostField', async () => {
+		const testPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Test post for field manipulation',
+		});
+
+		// Default should be 0
+		assert.strictEqual(testPost.anonymous, 0);
+
+		// Set to anonymous
+		await posts.setPostField(testPost.pid, 'anonymous', 1);
+		const updatedPost = await posts.getPostData(testPost.pid);
+		assert.strictEqual(updatedPost.anonymous, 1);
+
+		// Set back to non-anonymous
+		await posts.setPostField(testPost.pid, 'anonymous', 0);
+		const finalPost = await posts.getPostData(testPost.pid);
+		assert.strictEqual(finalPost.anonymous, 0);
+	});
+
+	it('should include anonymous field when getting post fields', async () => {
+		const anonymousPost = await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Test post for field retrieval',
+			anonymous: 1,
+		});
+
+		// Test getting specific fields including anonymous
+		const postFields = await posts.getPostFields(anonymousPost.pid, ['pid', 'uid', 'content', 'anonymous']);
+		assert.strictEqual(postFields.pid, anonymousPost.pid);
+		assert.strictEqual(postFields.uid, testUid);
+		assert.strictEqual(postFields.content, 'Test post for field retrieval');
+		assert.strictEqual(postFields.anonymous, 1);
+
+		// Test getting just the anonymous field
+		const anonymousField = await posts.getPostField(anonymousPost.pid, 'anonymous');
+		assert.strictEqual(anonymousField, 1);
+	});
+
+	it('should handle multiple posts with mixed anonymous status', async () => {
+		const postList = [];
+		
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Regular post 1',
+			anonymous: 0,
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Anonymous post 1',
+			anonymous: 1,
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Regular post 2',
+		}));
+
+		postList.push(await posts.create({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'Anonymous post 2',
+			anonymous: 1,
+		}));
+
+		// Get all posts and verify their anonymous status
+		const pids = postList.map(p => p.pid);
+		const allPosts = await posts.getPostsData(pids);
+
+		assert.strictEqual(allPosts.length, 4);
+		assert.strictEqual(allPosts[0].anonymous, 0);
+		assert.strictEqual(allPosts[1].anonymous, 1);
+		assert.strictEqual(allPosts[2].anonymous, 0);
+		assert.strictEqual(allPosts[3].anonymous, 1);
+	});
+});

--- a/test/topics.js
+++ b/test/topics.js
@@ -2306,6 +2306,39 @@ describe('Topic\'s', () => {
 		});
 	});
 
+	describe('recent topics', () => {
+		let category;
+		before(async () => {
+			category = await categories.create({ name: 'recent' });
+			// create a couple topics
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'first recent topic',
+				content: 'topic 1 OP',
+			});
+			await topics.post({
+				uid: topic.userId,
+				cid: category.cid,
+				title: 'second recent topic',
+				content: 'topic 2 OP',
+			});
+		});
+
+		it('should get topics ordered by most recent first', async () => {
+			const data = await topics.getRecentTopics({
+				cids: [category.cid],
+				uid: topic.userId,
+				start: 0,
+				stop: -1,
+			});
+			assert(data);
+			assert(Array.isArray(data.topics));
+			assert.strictEqual(data.topics[0].title, 'second recent topic');
+			assert.strictEqual(data.topics[1].title, 'first recent topic');
+		});
+	});
+	
 	describe('scheduled topics', () => {
 		let categoryObj;
 		let topicData;

--- a/test/topics/topics-setShowPreview.js
+++ b/test/topics/topics-setShowPreview.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const assert = require('assert');
+const User = require('../../src/user');
+const topicsAPI = require('../../src/api/topics');
+const topics = require('../../src/topics');
+
+describe('topicsAPI.setShowPreview', () => {
+	let adminUid;
+	let normalUid;
+	let tid;
+
+	before(async () => {
+		adminUid = await User.create({ username: 'testadmin' });
+		normalUid = await User.create({ username: 'testuser' });
+		// add admin to administrators group
+		await require('../../src/groups').join('administrators', adminUid);
+
+		// create a topic as admin
+		const { topicData } = await topics.post({ uid: adminUid, title: 'preview test', content: 'body', cid: 1 });
+		tid = topicData.tid;
+	});
+
+	it('should set showPreview for admin', async () => {
+		const res = await topicsAPI.setShowPreview({ uid: adminUid }, { tid, show: true });
+		assert.strictEqual(res.tid, tid);
+		assert.strictEqual(res.show, true);
+		const val = await topics.getTopicField(tid, 'showPreview');
+		assert.strictEqual(Number(val), 1);
+	});
+
+	it('should reject non-admin users', async () => {
+		try {
+			await topicsAPI.setShowPreview({ uid: normalUid }, { tid, show: true });
+			assert.fail('expected error');
+		} catch (err) {
+			assert.ok(err.message.includes('[[error:no-privileges]]'));
+		}
+	});
+});

--- a/test/upgrades/add-anonymous-field-to-posts.js
+++ b/test/upgrades/add-anonymous-field-to-posts.js
@@ -1,0 +1,231 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+
+const db = require('../mocks/databasemock');
+const posts = require('../../src/posts');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const user = require('../../src/user');
+
+const upgradeScript = require('../../src/upgrades/4.4.0/add-anonymous-field-to-posts');
+
+describe('Upgrade: Add anonymous field to posts', () => {
+	let testUid;
+	let testCid;
+	let topicData;
+	let postData1;
+	let postData2;
+	let postData3;
+
+	before(async () => {
+		// Create test user
+		testUid = await user.create({ username: 'testuser' });
+		
+		// Create test category
+		({ cid: testCid } = await categories.create({
+			name: 'Test Category',
+			description: 'Test category for upgrade testing',
+		}));
+
+		// Create test topic
+		({ topicData, postData: postData1 } = await topics.post({
+			uid: testUid,
+			cid: testCid,
+			title: 'Test Topic for Upgrade',
+			content: 'This is a test topic for upgrade testing',
+		}));
+
+		postData2 = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is a test reply for upgrade testing',
+		});
+
+		postData3 = await topics.reply({
+			uid: testUid,
+			tid: topicData.tid,
+			content: 'This is another test reply for upgrade testing',
+		});
+	});
+
+	describe('Pre-upgrade state', () => {
+		it('should have posts without anonymous field', async () => {
+			// Remove anonymous field from posts to simulate pre-upgrade state
+			await db.deleteObjectField(`post:${postData1.pid}`, 'anonymous');
+			await db.deleteObjectField(`post:${postData2.pid}`, 'anonymous');
+			await db.deleteObjectField(`post:${postData3.pid}`, 'anonymous');
+
+			// Check that posts exist but don't have anonymous field
+			const post1 = await db.getObject(`post:${postData1.pid}`);
+			const post2 = await db.getObject(`post:${postData2.pid}`);
+			const post3 = await db.getObject(`post:${postData3.pid}`);
+
+			assert(post1);
+			assert(post2);
+			assert(post3);
+			assert(!post1.hasOwnProperty('anonymous'));
+			assert(!post2.hasOwnProperty('anonymous'));
+			assert(!post3.hasOwnProperty('anonymous'));
+		});
+
+		it('should have posts in the posts:pid sorted set', async () => {
+			const allPids = await db.getSortedSetRange('posts:pid', 0, -1);
+			assert(allPids.length >= 3);
+			assert(allPids.includes(postData1.pid.toString()));
+			assert(allPids.includes(postData2.pid.toString()));
+			assert(allPids.includes(postData3.pid.toString()));
+		});
+	});
+
+	describe('Upgrade script execution', () => {
+		it('should have correct upgrade script metadata', () => {
+			assert.strictEqual(upgradeScript.name, 'Add anonymous field to posts');
+			assert(upgradeScript.timestamp);
+			assert(typeof upgradeScript.method, 'function');
+		});
+
+		it('should run upgrade script without errors', async () => {
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			// Run the upgrade script
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+	});
+
+	describe('Post-upgrade state', () => {
+		it('should add anonymous field to all existing posts', async () => {
+			// Check that all posts now have anonymous field set to 0
+			const post1 = await db.getObject(`post:${postData1.pid}`);
+			const post2 = await db.getObject(`post:${postData2.pid}`);
+			const post3 = await db.getObject(`post:${postData3.pid}`);
+
+			assert(post1);
+			assert(post2);
+			assert(post3);
+			assert(post1.hasOwnProperty('anonymous'));
+			assert(post2.hasOwnProperty('anonymous'));
+			assert(post3.hasOwnProperty('anonymous'));
+			assert.strictEqual(parseInt(post1.anonymous), 0);
+			assert.strictEqual(parseInt(post2.anonymous), 0);
+			assert.strictEqual(parseInt(post3.anonymous), 0);
+		});
+
+		it('should not modify posts that already have anonymous field', async () => {
+			// Create a new post with anonymous field already set
+			const newPost = await posts.create({
+				uid: testUid,
+				tid: topicData.tid,
+				content: 'This post already has anonymous field',
+				anonymous: 1,
+			});
+
+			// Run upgrade again
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+			await upgradeScript.method.bind({ progress: mockProgress })();
+
+			// Check that the post still has anonymous: 1
+			const post = await db.getObject(`post:${newPost.pid}`);
+			assert.strictEqual(parseInt(post.anonymous), 1);
+		});
+
+		it('should handle empty posts:pid set gracefully', async () => {
+			// Clear the posts:pid set
+			await db.delete('posts:pid');
+			
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+
+		it('should handle non-existent post objects gracefully', async () => {
+			// Add a non-existent pid to the posts:pid set
+			await db.sortedSetAdd('posts:pid', Date.now(), '999999');
+			
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+
+			await assert.doesNotReject(async () => {
+				await upgradeScript.method.bind({ progress: mockProgress })();
+			});
+		});
+	});
+
+	describe('Batch processing', () => {
+		it('should process posts in batches correctly', async () => {
+			// Create many posts to test batch processing
+			const manyPosts = [];
+			for (let i = 0; i < 10; i++) {
+				const post = await posts.create({
+					uid: testUid,
+					tid: topicData.tid,
+					content: `Batch test post ${i}`,
+				});
+				manyPosts.push(post);
+			}
+
+			// Remove anonymous field from these posts to simulate pre-upgrade state
+			for (const post of manyPosts) {
+				await db.deleteObjectField(`post:${post.pid}`, 'anonymous');
+			}
+
+			// Run upgrade script
+			const mockProgress = {
+				total: 0,
+				incr: function(count) {
+				}
+			};
+			await upgradeScript.method.bind({ progress: mockProgress })();
+
+			// Verify all posts now have anonymous field
+			for (const post of manyPosts) {
+				const postData = await db.getObject(`post:${post.pid}`);
+				assert(postData.hasOwnProperty('anonymous'));
+				assert.strictEqual(parseInt(postData.anonymous), 0);
+			}
+		});
+	});
+
+	describe('Integration with posts module', () => {
+		it('should work with posts.getPostData after upgrade', async () => {
+			const postData = await posts.getPostData(postData1.pid);
+			assert(postData);
+			assert.strictEqual(parseInt(postData.anonymous), 0);
+		});
+
+		it('should work with posts.getPostsData after upgrade', async () => {
+			const postsData = await posts.getPostsData([postData1.pid, postData2.pid, postData3.pid]);
+			assert.strictEqual(postsData.length, 3);
+			postsData.forEach(post => {
+				assert.strictEqual(parseInt(post.anonymous), 0);
+			});
+		});
+
+		it('should work with posts.getPostField after upgrade', async () => {
+			const anonymousField = await posts.getPostField(postData1.pid, 'anonymous');
+			assert.strictEqual(parseInt(anonymousField), 0);
+		});
+	});
+});

--- a/test/upgrades/add-anonymous-field-to-posts.js
+++ b/test/upgrades/add-anonymous-field-to-posts.js
@@ -89,8 +89,8 @@ describe('Upgrade: Add anonymous field to posts', () => {
 		it('should run upgrade script without errors', async () => {
 			const mockProgress = {
 				total: 0,
-				incr: function(count) {
-				}
+				incr: function (count) {
+				},
 			};
 
 			// Run the upgrade script
@@ -130,8 +130,8 @@ describe('Upgrade: Add anonymous field to posts', () => {
 			// Run upgrade again
 			const mockProgress = {
 				total: 0,
-				incr: function(count) {
-				}
+				incr: function (count) {
+				},
 			};
 			await upgradeScript.method.bind({ progress: mockProgress })();
 
@@ -147,8 +147,8 @@ describe('Upgrade: Add anonymous field to posts', () => {
 			// Run upgrade script
 			const mockProgress = {
 				total: 0,
-				incr: function(count) {
-				}
+				incr: function (count) {
+				},
 			};
 
 			await assert.doesNotReject(async () => {
@@ -163,8 +163,8 @@ describe('Upgrade: Add anonymous field to posts', () => {
 			// Run upgrade script
 			const mockProgress = {
 				total: 0,
-				incr: function(count) {
-				}
+				incr: function (count) {
+				},
 			};
 
 			await assert.doesNotReject(async () => {
@@ -194,8 +194,8 @@ describe('Upgrade: Add anonymous field to posts', () => {
 			// Run upgrade script
 			const mockProgress = {
 				total: 0,
-				incr: function(count) {
-				}
+				incr: function (count) {
+				},
 			};
 			await upgradeScript.method.bind({ progress: mockProgress })();
 

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
+			 
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -45,7 +45,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			 
+			// eslint-disable-next-line no-await-in-loop
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/anonymousToggle.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/anonymousToggle.tpl
@@ -1,0 +1,7 @@
+<div class="form-check form-check-inline">
+	<input class="form-check-input" type="checkbox" id="anonymous-checkbox" name="anonymous" title="[[category:anonymous-checkbox-tooltip]]">
+	<label class="form-check-label text-sm" for="anonymous-checkbox">
+		<i class="fa fa-user-secret me-1"></i>
+		Anonymous
+	</label>
+</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/newTopic.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/buttons/newTopic.tpl
@@ -1,22 +1,27 @@
 <noscript><div class="dropdown" component="category-selector"></noscript>
-<button component="category/post" for="category-dropdown-check" class="btn btn-primary btn-sm text-nowrap" id="new_topic" role="button">
-	[[category:new-topic-button]]
-</button>
+
+<div class="d-flex align-items-center gap-2">
+    <!-- New Topic Button -->
+    <button component="category/post" for="category-dropdown-check" class="btn btn-primary btn-sm text-nowrap" id="new_topic" role="button">
+        [[category:new-topic-button]]
+    </button>
+</div>
+
 <noscript>
-	<input type="checkbox" class="hidden" id="category-dropdown-check" aria-hidden="true">
-	<ul component="category/list" class="dropdown-menu p-1 text-sm category-dropdown-menu ghost-scrollbar" role="menu">
-		{{{each categories}}}
-		<li role="presentation" class="category {{{if categories.disabledClass}}}disabled{{{end}}}">
-			<a role="menu-item" href="{config.relative_path}/compose?cid={categories.cid}">{categories.level}
-				<span component="category-markup">
-					<div class="category-item d-inline-block">
-						{buildCategoryIcon(@value, "24px", "rounded-circle")}
-						{categories.name}
-					</div>
-				</span>
-			</a>
-		</li>
-		{{{end}}}
-	</ul>
+    <input type="checkbox" class="hidden" id="category-dropdown-check" aria-hidden="true">
+    <ul component="category/list" class="dropdown-menu p-1 text-sm category-dropdown-menu ghost-scrollbar" role="menu">
+        {{{each categories}}}
+        <li role="presentation" class="category {{{if categories.disabledClass}}}disabled{{{end}}}">
+			<a role="menu-item" href="{config.relative_path}/compose?cid={categories.cid}" class="new-topic-link">{categories.level}
+                <span component="category-markup">
+                    <div class="category-item d-inline-block">
+                        {buildCategoryIcon(@value, "24px", "rounded-circle")}
+                        {categories.name}
+                    </div>
+                </span>
+            </a>
+        </li>
+        {{{end}}}
+    </ul>
 </div>
 </noscript>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -38,10 +38,12 @@
 			<div class="d-flex gap-1 align-items-center">
 				{{{ if (template.category || template.world) }}}
 					{{{ if privileges.topics:create }}}
+					<!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}
+					<!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 					<!-- IMPORT partials/buttons/newTopic.tpl -->
 					{{{ end }}}
 				{{{ end }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -1,29 +1,36 @@
 {{{ if privileges.topics:reply }}}
 <div component="topic/quickreply/container" class="quick-reply d-flex gap-3 mb-4">
-	<div class="icon hidden-xs">
-		<a class="d-inline-block position-relative" href="{{{ if loggedInUser.userslug }}}{config.relative_path}/user/{loggedInUser.userslug}{{{ else }}}#{{{ end }}}">
-			{buildAvatar(loggedInUser, "48px", true, "", "user/picture")}
-			{{{ if loggedInUser.status }}}<span component="user/status" class="position-absolute top-100 start-100 border border-white border-2 rounded-circle status {loggedInUser.status}"><span class="visually-hidden">[[global:{loggedInUser.status}]]</span></span>{{{ end }}}
-		</a>
-	</div>
-	<form class="flex-grow-1 d-flex flex-column gap-2" method="post" action="{config.relative_path}/compose">
-		<input type="hidden" name="tid" value="{tid}" />
-		<input type="hidden" name="_csrf" value="{config.csrf_token}" />
-		<div class="quickreply-message position-relative">
-			<textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
-			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
-		</div>
-		<div>
-			<div class="d-flex justify-content-end gap-2">
-				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>
-				<button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
-				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
-			</div>
-		</div>
-	</form>
-	<form class="d-none" component="topic/quickreply/upload" method="post" enctype="multipart/form-data">
-		<input type="file" name="files[]" multiple class="hidden"/>
-	</form>
+    <div class="icon hidden-xs">
+        <a class="d-inline-block position-relative" href="{{{ if loggedInUser.userslug }}}{config.relative_path}/user/{loggedInUser.userslug}{{{ else }}}#{{{ end }}}">
+            {buildAvatar(loggedInUser, "48px", true, "", "user/picture")}
+            {{{ if loggedInUser.status }}}<span component="user/status" class="position-absolute top-100 start-100 border border-white border-2 rounded-circle status {loggedInUser.status}"><span class="visually-hidden">[[global:{loggedInUser.status}]]</span></span>{{{ end }}}
+        </a>
+    </div>
+    <form class="flex-grow-1 d-flex flex-column gap-2" method="post" action="{config.relative_path}/compose">
+        <input type="hidden" name="tid" value="{tid}" />
+        <input type="hidden" name="_csrf" value="{config.csrf_token}" />
+        <div class="quickreply-message position-relative">
+            <textarea rows="4" name="content" component="topic/quickreply/text" class="form-control mousetrap" placeholder="[[modules:composer.textarea.placeholder]]"></textarea>
+            <div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
+        </div>
+        <div>
+            <div class="d-flex justify-content-end gap-2 align-items-center">
+                <!-- Anonymous checkbox -->
+                <!-- IMPORT partials/buttons/anonymousToggle.tpl -->
 
+                <!-- Upload / Expand / Submit buttons -->
+                <button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border">
+                    <i class="fa fa-upload"></i>
+                </button>
+                <button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]">
+                    <i class="fa fa-expand"></i>
+                </button>
+                <button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
+            </div>
+        </div>
+    </form>
+    <form class="d-none" component="topic/quickreply/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="files[]" multiple class="hidden"/>
+    </form>
 </div>
 {{{ end }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,6 +23,11 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
+					{{{ if ./pinned && ./contentPreview }}}
+					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
+						{./contentPreview}
+					</div>
+					{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -23,11 +23,15 @@
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
 				</h3>
-					{{{ if ./pinned && ./contentPreview }}}
-					<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break">
-						{./contentPreview}
-					</div>
-					{{{ end }}}
+				{{{ if ./pinned }}}
+				<div class="topic-content-preview alert alert-info mt-2 mb-0 p-2 text-break w-100">
+    				{{{ if ./contentPreview }}}
+            	{{ ./contentPreview }}
+        		{{{ else }}}
+            	No preview available
+        		{{{ end }}}
+				</div>
+				{{{ end }}}
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">
 						<i class="fa fa-bell-o"></i>


### PR DESCRIPTION
TLDR: his PR introduces a showPreview flag on pinned topics, enabling authorized users to toggle whether content previews are displayed in category boards.

Issue: [#40 ](https://github.com/CMU-313/nodebb-fall-2025-slackers2/issues/40)

Changes made:

-API Layer: Created new endpoint to set the showPreview flag for a topic.
-Topic Schema: Added showPreview field to the Topic schema and persisted it in topic:<tid> hashes.
-Toggle Logic: Implemented backend handling so only pinned topics can have previews toggled.
-Rendering: Updated pinned topic query pipeline to respect showPreview and attach contentPreview conditionally.
-Testing: Added unit tests for backend toggle handling logic to ensure correct flag persistence and authorization.

Testing:

npm test -- test/topics/topics-setShowPreview.js (test/posts/topics-setShowPreview.js)

Credits: Tests were initially drafted by Copilot