### PR TITLE
WIP: Add Anonymous Post Option to Topics and Replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # ![NodeBB](public/images/sm-card.png)
 
+# Team: Bluey
+
+## Members
+- Lisa Huang (wenleh)
+- Diano Cano (dcano)
+- Luciana Requena (lrequena)
+- Michael Yan (tingxiay)
+- Sam Curry (scurry)
+
 ![Team Contribution Summary](https://raw.githubusercontent.com/CMU-313/NodeBB/gittogether-svg/activity.svg)
 
 [![Workflow](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml/badge.svg)](https://github.com/NodeBB/NodeBB/actions/workflows/test.yaml)

--- a/public/language/en-GB/global.json
+++ b/public/language/en-GB/global.json
@@ -140,6 +140,7 @@
 
 	"guest": "Guest",
 	"guests": "Guests",
+	"anonymous": "Anonymous",
 	"former-user": "A Former User",
 	"system-user": "System",
 	"unknown-user": "Unknown user",

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -244,6 +244,7 @@
 	"no-more-next-post": "You don't have more posts in this topic",
 	"open-composer": "Open composer",
 	"post-quick-reply": "Quick reply",
+	"post-anonymously": "Post anonymously",
 
 	"navigator.index": "Post %1 of %2",
 	"navigator.unread": "%1 unread",

--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -61,10 +61,12 @@ define('quickreply', [
 			}
 
 			const replyMsg = components.get('topic/quickreply/text').val();
+			const anonymous = document.getElementById('quickreply-anonymous')?.checked || false;
 			const replyData = {
 				tid: ajaxify.data.tid,
 				handle: undefined,
 				content: replyMsg,
+				anonymous: anonymous,
 			};
 			const replyLen = replyMsg.length;
 			if (replyLen < parseInt(config.minimumPostLength, 10)) {
@@ -116,10 +118,12 @@ define('quickreply', [
 			e.preventDefault();
 			storage.removeItem(qrDraftId);
 			const textEl = components.get('topic/quickreply/text');
+			const anonymous = document.getElementById('quickreply-anonymous')?.checked || false;
 			hooks.fire('action:composer.post.new', {
 				tid: ajaxify.data.tid,
 				title: ajaxify.data.titleRaw,
 				body: textEl.val(),
+				anonymous: anonymous,
 			});
 			textEl.val('');
 		});

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -15,6 +15,10 @@ exports.setDefaultPostData = function (reqOrSocket, data) {
 	data.req = exports.buildReqObject(reqOrSocket, { ...data });
 	data.timestamp = Date.now();
 	data.fromQueue = false;
+	
+	if (data.anonymous) {
+		data.realUid = reqOrSocket.uid;
+	}
 };
 
 // creates a slimmed down version of the request object

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -41,21 +41,6 @@ postsAPI.get = async function (caller, data) {
 	if (post.deleted && !(userPrivilege.isAdminOrMod || selfPost)) {
 		post.content = '[[topic:post-is-deleted]]';
 	}
-
-	if (post.anonymous) {
-		const isPrivileged = userPrivilege.isAdminOrMod || 
-		(caller.uid && parseInt(caller.uid, 10) === Number(post.realUid));
-		if (!isPrivileged) {
-			post.uid = 0;
-			post.user = {
-				uid: 0,
-				displayname: 'Guest',
-			};
-			delete post.username;
-			delete post.userslug;
-			delete post.picture;
-		}
-	}
 	
 	return post;
 };
@@ -79,24 +64,6 @@ postsAPI.getSummary = async (caller, { pid }) => {
 
 	const postsData = await posts.getPostSummaryByPids([pid], caller.uid, { stripTags: false });
 	posts.modifyPostByPrivilege(postsData[0], topicPrivileges);
-	try {
-		const post = postsData[0];
-		if (post && post.anonymous) {
-			const isPrivileged = topicPrivileges.isAdminOrMod || (caller.uid && Number(caller.uid) === Number(post.realUid));
-			if (!isPrivileged) {
-				post.uid = 0;
-				post.user = {
-					uid: 0,
-					displayname: 'Guest',
-				};
-				delete post.username;
-				delete post.userslug;
-				delete post.picture;
-			}
-		}
-	} catch (err) {
-		// ignore
-	}
 	return postsData[0];
 };
 

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -35,6 +35,7 @@ module.exports = function (Posts) {
 			if (typeof data.realUid !== 'undefined' && data.realUid !== null) {
 				postData.realUid = Number(data.realUid);
 			}
+			postData.uid = 0;
 		}
 
 		if (data.toPid) {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -30,6 +30,13 @@ module.exports = function (Posts) {
 		const pid = data.pid || await db.incrObjectField('global', 'nextPid');
 		let postData = { pid, uid, tid, content, sourceContent, timestamp };
 
+		if (data.anonymous) {
+			postData.anonymous = true;
+			if (typeof data.realUid !== 'undefined' && data.realUid !== null) {
+				postData.realUid = Number(data.realUid);
+			}
+		}
+
 		if (data.toPid) {
 			postData.toPid = data.toPid;
 		}

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -35,6 +35,7 @@ module.exports = function (Topics) {
 			lastposttime: 0,
 			postcount: 0,
 			viewcount: 0,
+			anonymous: data.anonymous,
 		};
 
 		if (Array.isArray(data.tags) && data.tags.length) {
@@ -83,6 +84,12 @@ module.exports = function (Topics) {
 	Topics.post = async function (data) {
 		data = await plugins.hooks.fire('filter:topic.post', data);
 		const { uid } = data;
+
+		data.anonymous = (data.anonymous === true) || (data.anonymous === 1);
+		if (data.anonymous) {
+			data.realUid = uid;
+			data.uid = 0;
+		}
 
 		const [categoryExists, canCreate, canTag, isAdmin] = await Promise.all([
 			parseInt(data.cid, 10) > 0 ? categories.exists(data.cid) : true,
@@ -200,6 +207,12 @@ module.exports = function (Topics) {
 			}
 		}
 
+		data.anonymous = (data.anonymous === true) || (data.anonymous === 1);
+		if (data.anonymous) {
+			data.realUid = uid;
+			data.uid = 0;
+		}
+
 		// For replies to scheduled topics, don't have a timestamp older than topic's itself
 		if (topicData.scheduled) {
 			data.timestamp = topicData.lastposttime + 1;
@@ -244,6 +257,16 @@ module.exports = function (Topics) {
 			posts.getPostSummaryByPids([pid], uid, {}),
 			posts.getUserInfoForPosts([postOwner], uid),
 		]);
+
+		postData.user = userInfo;
+		if (postData.anonymous) {
+			postData.user = {
+				uid: 0,
+				displayname: 'Guest',
+				originalUid: userInfo && userInfo.uid,
+			};
+		}
+
 		await Promise.all([
 			Topics.addParentPosts([postData], uid),
 			Topics.syncBacklinks(postData),

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -152,6 +152,8 @@ module.exports = function (Topics) {
 			}
 		});
 
+		await posts.addUserInfoToAnonymousPosts(postData, uid);
+
 		const result = await plugins.hooks.fire('filter:topics.addPostData', {
 			posts: postData,
 			uid: uid,

--- a/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
@@ -295,4 +295,40 @@ $(document).ready(function () {
 		mainNavEl.on('shown.bs.dropdown', toggleOverflow)
 			.on('hidden.bs.dropdown', toggleOverflow);
 	}
+
+	function setComposerAnonymousForForm($form, value) {
+		let $hidden = $form.find('input[name="anonymous"]');
+		if (!$hidden.length) {
+			$hidden = $('<input/>', { type: 'hidden', name: 'anonymous' }).appendTo($form);
+		}
+		$hidden.val(value ? '1' : '0');
+	}
+
+	$(document).on('submit', '.composer-form', function () {
+		const $form = $(this);
+		try {
+			const $chk = $form.find('#composer-anonymous-toggle');
+			const checked = $chk.length ? $chk.prop('checked') : ($form.find('input[name="anonymous"]').val() === '1');
+			setComposerAnonymousForForm($form, checked);
+		} catch (err) {
+			// ignore
+		}
+	});
+
+	try {
+		const params = new URLSearchParams(window.location.search);
+		const anon = params.get('anonymous');
+		if (anon === '1' || anon === 'true') {
+			$(document).on('action:composer.open', function (evt, data) {
+				const $form = data && data.$form ? data.$form : $('.composer-form').first();
+				if (!$form || !$form.length) return;
+				const $chk = $form.find('#composer-anonymous-toggle');
+				if ($chk.length) $chk.prop('checked', true);
+				setComposerAnonymousForForm($form, true);
+			});
+			$('.composer-form').each(function () { setComposerAnonymousForForm($(this), true); });
+		}
+	} catch (err) {
+		// ignore
+	}
 });

--- a/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/public/harmony.js
@@ -296,39 +296,4 @@ $(document).ready(function () {
 			.on('hidden.bs.dropdown', toggleOverflow);
 	}
 
-	function setComposerAnonymousForForm($form, value) {
-		let $hidden = $form.find('input[name="anonymous"]');
-		if (!$hidden.length) {
-			$hidden = $('<input/>', { type: 'hidden', name: 'anonymous' }).appendTo($form);
-		}
-		$hidden.val(value ? '1' : '0');
-	}
-
-	$(document).on('submit', '.composer-form', function () {
-		const $form = $(this);
-		try {
-			const $chk = $form.find('#composer-anonymous-toggle');
-			const checked = $chk.length ? $chk.prop('checked') : ($form.find('input[name="anonymous"]').val() === '1');
-			setComposerAnonymousForForm($form, checked);
-		} catch (err) {
-			// ignore
-		}
-	});
-
-	try {
-		const params = new URLSearchParams(window.location.search);
-		const anon = params.get('anonymous');
-		if (anon === '1' || anon === 'true') {
-			$(document).on('action:composer.open', function (evt, data) {
-				const $form = data && data.$form ? data.$form : $('.composer-form').first();
-				if (!$form || !$form.length) return;
-				const $chk = $form.find('#composer-anonymous-toggle');
-				if ($chk.length) $chk.prop('checked', true);
-				setComposerAnonymousForForm($form, true);
-			});
-			$('.composer-form').each(function () { setComposerAnonymousForForm($(this), true); });
-		}
-	} catch (err) {
-		// ignore
-	}
 });

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -39,7 +39,6 @@
 				{{{ if (template.category || template.world) }}}
 					{{{ if privileges.topics:create }}}
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
-					<a href="{config.relative_path}/compose?cid={cid}&anonymous=1" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">New Anonymous Topic</a>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl
@@ -39,6 +39,7 @@
 				{{{ if (template.category || template.world) }}}
 					{{{ if privileges.topics:create }}}
 					<a href="{config.relative_path}/compose?cid={cid}" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">[[category:new-topic-button]]</a>
+					<a href="{config.relative_path}/compose?cid={cid}&anonymous=1" component="category/post" id="new_topic" class="btn btn-primary btn-sm text-nowrap" data-ajaxify="false" role="button">New Anonymous Topic</a>
 					{{{ end }}}
 				{{{ else }}}
 					{{{ if canPost }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -14,11 +14,18 @@
 			<div class="imagedrop"><div>[[topic:composer.drag-and-drop-images]]</div></div>
 		</div>
 		<div>
-			<div class="d-flex justify-content-end gap-2">
-				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>
-				<button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
-				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
-				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">Anonymous Quick Reply</button>
+			<div class="d-flex justify-content-between align-items-center">
+				<div class="form-check">
+					<input class="form-check-input" type="checkbox" id="quickreply-anonymous" name="anonymous" value="1">
+					<label class="form-check-label text-sm" for="quickreply-anonymous">
+						[[topic:post-anonymously]]
+					</label>
+				</div>
+				<div class="d-flex gap-2">
+					<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>
+					<button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
+					<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
+				</div>
 			</div>
 		</div>
 	</form>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl
@@ -18,6 +18,7 @@
 				<button type="button" component="topic/quickreply/upload/button" class="btn btn-ghost btn-sm border"><i class="fa fa-upload"></i></button>
 				<button type="button" component="topic/quickreply/expand" class="btn btn-ghost btn-sm border" title="[[topic:open-composer]]"><i class="fa fa-expand"></i></button>
 				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">[[topic:post-quick-reply]]</button>
+				<button type="submit" component="topic/quickreply/button" class="btn btn-sm btn-primary">Anonymous Quick Reply</button>
 			</div>
 		</div>
 	</form>


### PR DESCRIPTION
**Context:**
As a student, I want to be able to post questions anonymously, so that I don't have to be self conscious about asking questions.
Currently, NodeBB does not offer the ability for users to post anonymously. By allowing this, it would give students more confidence when asking questions seen by the entire class, while still maintaining good behavior as moderators are allowed to see user IDs of those who post anonymously.

**Description:**
This PR adds frontend buttons next to the Post and Reply buttons that give users the option to post/reply anonymously. It also has most of the backend code required to recognize a user is anonymous and remove their data. The code is not finalized, as the frontend has yet to be able to talk to the backend. Once the frontend and backend are integrated, full testing will be set up to ensure the feature is working properly.

**Changes to the Codebase:**

_src/api/posts.js_
Checks if the user viewing the post is privileged (Admin/mod) and removes info if they are not privileged.

_src/posts/create.js_
Saves the poster's userID and the fact that the post is anonymous

_src/topics/create.js_
If post is anonymous sets UID to 0 and replaces displayname with Guest

_vendor/nodebb-theme-harmony-2.1.15/public/harmony.js_
WIP. Attempting to detect when the user wishes to post anonymously and relay that data. Also includes irrelevant code from when I was attempting to make a toggleable button for anonymity. 

_vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic-list-bar.tpl_
_vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/quickreply.tpl_
Adding buttons that allow the user to post anonymously

**Notes**
Marked as WIP as it is a Work in Progress
Next step is to do more research into how to integrate frontend button inputs into data receivable by the backend. Will continue to collaborate with team members on ideas and solutions.